### PR TITLE
'make install' should install bin/bamtools

### DIFF
--- a/src/toolkit/CMakeLists.txt
+++ b/src/toolkit/CMakeLists.txt
@@ -38,3 +38,5 @@ configure_file(bamtools_version.h.in ${BamTools_SOURCE_DIR}/src/toolkit/bamtools
 # define libraries to link
 target_link_libraries ( bamtools BamTools BamTools-utils jsoncpp )
 
+# set application install destinations
+install( TARGETS bamtools DESTINATION "bin")


### PR DESCRIPTION
Running 'make install' installed only the library and headers. This patch makes it install bin/bamtools as well.
