### PR TITLE
Fixes for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,8 @@ set (EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin")
 set (LIBRARY_OUTPUT_PATH    "${CMAKE_SOURCE_DIR}/lib")
 
 # define compiler flags for all code
-add_definitions (-Wall -O2 -D_FILE_OFFSET_BITS=64)
+set (CMAKE_BUILD_TYPE Release)
+add_definitions (-Wall -D_FILE_OFFSET_BITS=64)
 
 # add our includes root path
 include_directories (src)

--- a/src/api/BamAlignment.cpp
+++ b/src/api/BamAlignment.cpp
@@ -154,16 +154,18 @@ bool BamAlignment::AddTag(const std::string& tag, const std::string& type, const
     // otherwise, copy tag data to temp buffer
     string newTag = tag + type + value;
     const int newTagDataLength = tagDataLength + newTag.size() + 1; // leave room for null-term
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength + 1);    // '+1' for TagData null-term
-    
+
     // append newTag
     strcat(originalTagData + tagDataLength, newTag.data());  // removes original null-term, appends newTag + null-term
-    
+
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
     
+    delete[] originalTagData;
+
     // return success
     return true;
 }
@@ -213,7 +215,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::string& type, const
     // copy original tag data to temp buffer
     string newTag = tag + type;
     const int newTagDataLength = tagDataLength + newTag.size() + 4; // leave room for new integer
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength + 1);    // '+1' for TagData null-term
     
     // append newTag
@@ -223,6 +225,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::string& type, const
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+    delete[] originalTagData;
     
     // return success
     return true;
@@ -288,7 +291,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::string& type, const
     // copy original tag data to temp buffer
     string newTag = tag + type;
     const int newTagDataLength = tagDataLength + newTag.size() + 4; // leave room for new float
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength + 1);    // '+1' for TagData null-term
     
     // append newTag
@@ -299,6 +302,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::string& type, const
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
     
+    delete[] originalTagData;
+
     // return success
     return true;
 }
@@ -346,7 +351,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint8_t>& va
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(uint8_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -363,6 +368,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint8_t>& va
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -411,7 +418,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int8_t>& val
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(int8_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -428,6 +435,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int8_t>& val
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -476,7 +485,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint16_t>& v
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(uint16_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -493,6 +502,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint16_t>& v
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -541,7 +552,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int16_t>& va
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(int16_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -558,6 +569,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int16_t>& va
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -606,7 +619,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint32_t>& v
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(uint32_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -623,6 +636,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<uint32_t>& v
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -671,7 +686,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int32_t>& va
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(int32_t);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -688,6 +703,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<int32_t>& va
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -736,7 +753,7 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<float>& valu
     const int newTagDataLength = tagDataLength +
                                  Constants::BAM_TAG_ARRAYBASE_SIZE +
                                  numElements*sizeof(float);
-    char originalTagData[newTagDataLength];
+    char* originalTagData = new char[newTagDataLength];
     memcpy(originalTagData, TagData.c_str(), tagDataLength+1); // '+1' for TagData's null-term
 
     // write newTagBase (removes old null term)
@@ -753,6 +770,8 @@ bool BamAlignment::AddTag(const std::string& tag, const std::vector<float>& valu
     // store temp buffer back in TagData
     const char* newTagData = (const char*)originalTagData;
     TagData.assign(newTagData, newTagDataLength);
+
+    delete[] originalTagData;
 
     // return success
     return true;
@@ -1024,7 +1043,7 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
     if ( FindTag(tag, pTagData, originalTagDataLength, numBytesParsed) ) {
         
         // make sure array is more than big enough
-        char newTagData[originalTagDataLength + value.size()];  
+        char* newTagData = new char[originalTagDataLength + value.size()];  
 
         // copy original tag data up til desired tag
         const unsigned int beginningTagDataLength = numBytesParsed;
@@ -1051,6 +1070,9 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
         
         // save new tag data
         TagData.assign(newTagData, endTagOffset + endTagDataLength);
+
+        delete[] newTagData;
+
         return true;
     }
     
@@ -1100,7 +1122,7 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
     if ( FindTag(tag, pTagData, originalTagDataLength, numBytesParsed) ) {
         
         // make sure array is more than big enough
-        char newTagData[originalTagDataLength + sizeof(value)];  
+        char* newTagData = new char[originalTagDataLength + sizeof(value)];  
 
         // copy original tag data up til desired tag
         const unsigned int beginningTagDataLength = numBytesParsed;
@@ -1128,6 +1150,9 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
         
         // save new tag data
         TagData.assign(newTagData, endTagOffset + endTagDataLength);
+
+        delete[] newTagData;
+
         return true;
     }
     
@@ -1194,7 +1219,7 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
     if ( FindTag(tag, pTagData, originalTagDataLength, numBytesParsed) ) {
         
         // make sure array is more than big enough
-        char newTagData[originalTagDataLength + sizeof(value)];  
+        char* newTagData = new char[originalTagDataLength + sizeof(value)];  
 
         // copy original tag data up til desired tag
         const unsigned int beginningTagDataLength = numBytesParsed;
@@ -1222,6 +1247,9 @@ bool BamAlignment::EditTag(const std::string& tag, const std::string& type, cons
         
         // save new tag data
         TagData.assign(newTagData, endTagOffset + endTagDataLength);
+
+        delete[] newTagData;
+
         return true;
     }
     
@@ -2154,7 +2182,7 @@ bool BamAlignment::RemoveTag(const std::string& tag) {
     // if tag found
     if ( FindTag(tag, pTagData, originalTagDataLength, numBytesParsed) ) {
         
-        char newTagData[originalTagDataLength];
+        char* newTagData = new char[originalTagDataLength];
 
         // copy original tag data up til desired tag
         pTagData       -= 3;
@@ -2177,6 +2205,9 @@ bool BamAlignment::RemoveTag(const std::string& tag) {
         
         // save new tag data
         TagData.assign(newTagData, beginningTagDataLength + endTagDataLength);
+
+        delete[] newTagData;
+
         return true;
     }
     

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries( BamTools z )
 target_link_libraries( BamTools-static z )
 
 # set library install destinations
-install( TARGETS BamTools LIBRARY DESTINATION "lib/bamtools")
+install( TARGETS BamTools LIBRARY DESTINATION "lib/bamtools" RUNTIME DESTINATION "bin")
 install( TARGETS BamTools-static ARCHIVE DESTINATION "lib/bamtools")
 
 # export API headers

--- a/src/toolkit/CMakeLists.txt
+++ b/src/toolkit/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories ( ${BamTools_SOURCE_DIR}/src/api
                     )
 
 # compile main bamtools application
-add_executable ( bamtools
+add_executable ( bamtools_cmd
                  bamtools_convert.cpp
                  bamtools_count.cpp
                  bamtools_coverage.cpp
@@ -22,7 +22,7 @@ add_executable ( bamtools
                  bamtools_merge.cpp
                  bamtools_random.cpp
                  bamtools_resolve.cpp
-		         bamtools_revert.cpp
+                 bamtools_revert.cpp
                  bamtools_sort.cpp
                  bamtools_split.cpp
                  bamtools_stats.cpp
@@ -30,14 +30,15 @@ add_executable ( bamtools
                )
 
 # set BamTools application properties
-set_target_properties( BamTools PROPERTIES
+set_target_properties( bamtools_cmd PROPERTIES
                        VERSION  1.0.2
+                       OUTPUT_NAME "bamtools"
                      )
 # make version info available in application
 configure_file(bamtools_version.h.in ${BamTools_SOURCE_DIR}/src/toolkit/bamtools_version.h)
 
 # define libraries to link
-target_link_libraries ( bamtools BamTools BamTools-utils jsoncpp )
+target_link_libraries ( bamtools_cmd BamTools BamTools-utils jsoncpp )
 
 # set application install destinations
-install( TARGETS bamtools DESTINATION "bin")
+install( TARGETS bamtools_cmd DESTINATION "bin")

--- a/src/utils/bamtools_fasta.cpp
+++ b/src/utils/bamtools_fasta.cpp
@@ -20,6 +20,11 @@ using namespace BamTools;
 #include <vector>
 using namespace std;
 
+#ifdef _MSC_VER
+	#define ftello _ftelli64
+	#define fseeko _fseeki64
+#endif
+
 struct Fasta::FastaPrivate {
   
     struct FastaIndexData {

--- a/src/utils/bamtools_utilities.cpp
+++ b/src/utils/bamtools_utilities.cpp
@@ -309,7 +309,7 @@ vector<string> Utilities::Split(const string& source, const string& delims) {
     vector<string> fields;
 
     char* tok;
-    char cchars [source.size()+1];
+    char* cchars = new char[source.size()+1];
     char* cstr = &cchars[0];
     strcpy(cstr, source.c_str());
     tok = strtok(cstr, delims.c_str());
@@ -317,6 +317,8 @@ vector<string> Utilities::Split(const string& source, const string& delims) {
         fields.push_back(tok);
         tok = strtok(NULL, delims.c_str());
     }
+
+    delete[] cchars;
 
     return fields;
 }


### PR DESCRIPTION
Don't use dynamic stack allocation (variable length arrays).
Rename bamtools target to bamtools_cmd to not conflict with BamTools target (they differ only in case).
To get bamtools_cmd to compile I had to remove bamtools_filter.cpp (which I haven't committed).
I also had to manually configure the include directory for zlib, but that's probably due to having multiple copies floating around my machine.

I've only tested that I can run "bamtools header -in ..."
