### PR TITLE
Bug discovered. The chunkStop was not being read from the correct offset 

### DIFF
--- a/src/api/internal/BamStandardIndex_p.cpp
+++ b/src/api/internal/BamStandardIndex_p.cpp
@@ -125,7 +125,7 @@ bool BamStandardIndex::CalculateCandidateOffsets(const BaiReferenceSummary& refS
                 // read chunk start & stop from buffer
                 memcpy((char*)&chunkStart, m_buffer+offset, sizeof(uint64_t));
                 offset += sizeof(uint64_t);
-                memcpy((char*)&chunkStop, m_buffer, sizeof(uint64_t));
+                memcpy((char*)&chunkStop, m_buffer+offset, sizeof(uint64_t));
                 offset += sizeof(uint64_t);
 
                 // swap endian-ness if necessary


### PR DESCRIPTION
Bug discovered. The chunkStop was not being read from the correct offset (rather always being read as the first chunkStart value for the # alignment chunks in that bin of the index.

The result of this is that chunkStop will never be >= minOffset (or maybe rarely, since it always equals the first chunkStart for the first chunk) and thus the linear index doesn't really help in reducing the number of seeks performed.
