### PR TITLE
Crash in BamStandardIndex::GetOffset for small BAM files

### DIFF
--- a/src/api/internal/BamStandardIndex_p.cpp
+++ b/src/api/internal/BamStandardIndex_p.cpp
@@ -434,6 +434,12 @@ bool BamStandardIndex::GetOffset(const BamRegion& region, int64_t& offset, bool*
         return false;
     }
 
+    // if not candidate offsets are present in the indexed (most likely sparce coverage)
+    // then silently bail
+    if( offsets.size() == 0 ) {
+        return false;
+    }
+    
     // ensure that offsets are sorted before processing
     sort( offsets.begin(), offsets.end() );
 


### PR DESCRIPTION
In standard indexed BAM files with with sparce coverage (our test case was a roughly 1M read RNAseq BAM file), queries made to intervals may not have any of the candidate offesets present in the index as the BAM index only contains bins that have reads.

Without this bail out, we would get a crash. Returning false silently is the preferred behavior in our view as it allows our read logic to go to the next query and does not add noise to stderr.
