### PR TITLE
Comments are lost from header when copying a SamHeader

### DIFF
--- a/src/api/SamHeader.cpp
+++ b/src/api/SamHeader.cpp
@@ -72,6 +72,7 @@ SamHeader::SamHeader(const SamHeader& other)
     , Sequences(other.Sequences)
     , ReadGroups(other.ReadGroups)
     , Programs(other.Programs)
+    , Comments(other.Comments)
 { }
 
 /*! \fn SamHeader::~SamHeader(void)


### PR DESCRIPTION
When copying a SamHeader object, any comments contained in the header are lost. This is due to a bug in the copy constructor- a simple one-liner fix is attached.
