### PR TITLE
Fix uninitialized buffer in BamReaderPrivate::LoadNextAlignment

### DIFF
--- a/src/api/internal/bam/BamReader_p.cpp
+++ b/src/api/internal/bam/BamReader_p.cpp
@@ -232,6 +232,7 @@ bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 
     // read in the 'block length' value, make sure it's not zero
     char buffer[sizeof(uint32_t)];
+    fill_n(buffer, sizeof(uint32_t), 0);
     m_stream.Read(buffer, sizeof(uint32_t));
     alignment.SupportData.BlockLength = BamTools::UnpackUnsignedInt(buffer);
     if ( m_isBigEndian ) BamTools::SwapEndian_32(alignment.SupportData.BlockLength);


### PR DESCRIPTION
Normally, the variable "buffer" is filled by the call to m_stream.Read (BamReader_p.cpp:235). When the input file has ended (i.e. no more bytes are available), however, m_stream.Read does not write to the buffer. This ultimately results in alignment.SupportData.BlockLength being uninitialized and the outcome of the if-clause in line 238 being undefined.

Therefore, I've added a fill_n to inizialize the buffer.
