### PR TITLE
Include header sys/filio.h when compiling on SunOS. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ set( LIBRARY_OUTPUT_PATH    "${CMAKE_SOURCE_DIR}/lib" )
 # define compiler flags for all code
 set( CMAKE_BUILD_TYPE Release )
 add_definitions( -Wall -D_FILE_OFFSET_BITS=64 )
+if( "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS" )
+	add_definitions( -DSUN_OS )
+endif()
 
 # add our includes root path
 include_directories( src )

--- a/src/api/internal/io/TcpSocketEngine_unix_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_unix_p.cpp
@@ -12,6 +12,10 @@
 using namespace BamTools;
 using namespace BamTools::Internal;
 
+#ifdef SUN_OS
+#include <sys/filio.h> 
+#endif
+
 #include <cerrno>
 #include <ctime>
 #include <iostream>


### PR DESCRIPTION
If this header is missing, TcpSocketEngine_unix_p.cpp does not compile because FIONREAD is not found.
