### PR TITLE
fixed copy of SamHeader.cpp

### DIFF
--- a/src/api/SamHeader.cpp
+++ b/src/api/SamHeader.cpp
@@ -73,6 +73,7 @@ SamHeader::SamHeader(const SamHeader& other)
     , ReadGroups(other.ReadGroups)
     , Programs(other.Programs)
     , Comments(other.Comments)
+    , m_errorString(other.GetErrorString())
 { }
 
 /*! \fn SamHeader::~SamHeader(void)


### PR DESCRIPTION
I fixed the error message not getting passed when the copy constructor is implicitly called.
