### PR TITLE
Install libbamtools to $prefix/lib

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -54,8 +54,8 @@ target_link_libraries( BamTools        ${APILibs} )
 target_link_libraries( BamTools-static ${APILibs} )
 
 # set library install destinations
-install( TARGETS BamTools        LIBRARY DESTINATION "lib/bamtools" RUNTIME DESTINATION "bin")
-install( TARGETS BamTools-static ARCHIVE DESTINATION "lib/bamtools")
+install( TARGETS BamTools        LIBRARY DESTINATION "lib" RUNTIME DESTINATION "bin")
+install( TARGETS BamTools-static ARCHIVE DESTINATION "lib")
 
 # export API headers
 include(../ExportHeader.cmake)


### PR DESCRIPTION
Installing libraries to `$prefix/lib/bamtools` requires setting `LD_LIBRARY_PATH` or the executable's rpath. Installing libraries to `$prefix/lib` is cleaner.
