### PR TITLE
Include for 'netinet/in.h' to NetUnix_p.h  allows compilation on FreeBSD

### DIFF
--- a/src/api/internal/io/NetUnix_p.h
+++ b/src/api/internal/io/NetUnix_p.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <netinet/in.h>
 
 #ifndef   BT_SOCKLEN_T
 #  define BT_SOCKLEN_T socklen_t


### PR DESCRIPTION
libbamtools won't compile on FreeBSD, throwing errors that `sockaddr_in`and others are not defined. It seems these variables are defined in `netinet/in.h` for FreeBSD. 

Adding this include means libbamtools compiles happily on both our FreeBSD machine and (still) on my Ubuntu box. 