### PR TITLE
Prevent warnings due to struct/class tag mixups

### DIFF
--- a/src/api/BamAlignment.h
+++ b/src/api/BamAlignment.h
@@ -29,7 +29,7 @@ namespace Internal {
 //! \endcond
 
 // BamAlignment data structure
-struct API_EXPORT BamAlignment {
+class API_EXPORT BamAlignment {
 
     // constructors & destructor
     public:

--- a/src/api/SamHeader.h
+++ b/src/api/SamHeader.h
@@ -19,7 +19,8 @@
 
 namespace BamTools {
 
-struct API_EXPORT SamHeader {
+class API_EXPORT SamHeader {
+    public:
 
     // ctor & dtor
     SamHeader(const std::string& headerText = "");

--- a/src/api/internal/io/TcpSocketEngine_p.h
+++ b/src/api/internal/io/TcpSocketEngine_p.h
@@ -30,7 +30,7 @@
 namespace BamTools {
 namespace Internal {
 
-struct TcpSocketEngine {
+class TcpSocketEngine {
 
     // ctors & dtor
     public:

--- a/src/api/internal/sam/SamHeaderValidator_p.h
+++ b/src/api/internal/sam/SamHeaderValidator_p.h
@@ -27,8 +27,8 @@
 namespace BamTools {
 
 class SamHeader;
-class SamReadGroup;
-class SamSequence;
+struct SamReadGroup;
+struct SamSequence;
 
 namespace Internal {
 

--- a/src/toolkit/bamtools_filter.h
+++ b/src/toolkit/bamtools_filter.h
@@ -28,7 +28,7 @@ class FilterTool : public AbstractTool {
         struct FilterSettings;
         FilterSettings* m_settings;
         
-        struct FilterToolPrivate;
+        class FilterToolPrivate;
         FilterToolPrivate* m_impl;
 };
   

--- a/src/toolkit/bamtools_sort.h
+++ b/src/toolkit/bamtools_sort.h
@@ -28,7 +28,7 @@ class SortTool : public AbstractTool {
         struct SortSettings;
         SortSettings* m_settings;
         
-        struct SortToolPrivate;
+        class SortToolPrivate;
         SortToolPrivate* m_impl;
 };
   

--- a/src/toolkit/bamtools_split.h
+++ b/src/toolkit/bamtools_split.h
@@ -29,7 +29,7 @@ class SplitTool : public AbstractTool {
         struct SplitSettings;
         SplitSettings* m_settings;
         
-        struct SplitToolPrivate;
+        class SplitToolPrivate;
         SplitToolPrivate* m_impl;
 };
   


### PR DESCRIPTION
Some compilers, e.g., the version of clang that comes with OS X Mavericks, produce warnings of the form

> In file included from src/toolkit/bamtools_merge.cpp:13:
> src/api/BamWriter.h:19:1: warning: class 'BamAlignment' was previously declared as a struct
> _class BamAlignment;_
> src/api/BamAlignment.h:32:19: note: previous use is here
> _struct API_EXPORT BamAlignment_

when a type is declared as a struct and later defined as a class, or vice versa.  When, as here, both are in header files, the diagnostic may be repeated for many translation units.

These suggested patches resolve these discrepancies.  Especially for a couple of the API ones, it would be worth reviewing the direction in which I've resolved them.
