### PR TITLE
Add bamtools-utils to install target

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -28,3 +28,6 @@ set_target_properties( BamTools-utils PROPERTIES
                        OUTPUT_NAME bamtools-utils
                        PREFIX "lib"
                      )
+
+# set library install destinations
+install( TARGETS BamTools-utils ARCHIVE DESTINATION "lib/bamtools")


### PR DESCRIPTION
Could you please incorporate this patch so that libbamtools-utils will get installed in the standard bamtools library  location?
