### PR TITLE
Fix building with C++11 and above

### DIFF
--- a/src/toolkit/bamtools_resolve.cpp
+++ b/src/toolkit/bamtools_resolve.cpp
@@ -410,7 +410,7 @@ bool ResolveTool::ReadNamesFileReader::Read(map<string, ReadGroupResolver>& read
         ReadGroupResolver& resolver = (*rgIter).second;
 
         // store read name with resolver
-        resolver.ReadNames.insert( make_pair<string,bool>(fields[1], true) ) ;
+        resolver.ReadNames.insert( make_pair(fields[1], true) ) ;
     }
 
     // if here, return success
@@ -607,7 +607,7 @@ bool ResolveTool::StatsFileReader::ParseReadGroupLine(const string& line,
     resolver.IsAmbiguous = ( fields.at(6) == TRUE_KEYWORD );
 
     // store RG entry and return success
-    readGroups.insert( make_pair<string, ReadGroupResolver>(name, resolver) );
+    readGroups.insert( make_pair(name, resolver) );
     return true;
 }
 
@@ -1014,7 +1014,7 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
         }
 
         // if read name not found, store new entry
-        else resolver.ReadNames.insert( make_pair<string, bool>(al.Name, isCurrentMateUnique) );
+        else resolver.ReadNames.insert( make_pair(al.Name, isCurrentMateUnique) );
     }
 
     // close files
@@ -1046,7 +1046,7 @@ void ResolveTool::ResolveToolPrivate::ParseHeader(const SamHeader& header) {
     SamReadGroupConstIterator rgEnd  = header.ReadGroups.ConstEnd();
     for ( ; rgIter != rgEnd; ++rgIter ) {
         const SamReadGroup& rg = (*rgIter);
-        m_readGroups.insert( make_pair<string, ReadGroupResolver>(rg.ID, ReadGroupResolver()) );
+        m_readGroups.insert( make_pair(rg.ID, ReadGroupResolver()) );
     }
 }
 


### PR DESCRIPTION
* Using std::make_pair with explicit arguments is pointless
  as it solely exists to do argument type deduction as a
  factory function. See also:
    http://www.advogato.org/person/redi/diary/239.html

Fixes #115
Fixes #140
Fixes #148