### PR TITLE
Fix warning when compiling in C++11 mode due to narrowing conversions

### DIFF
--- a/src/api/BamConstants.h
+++ b/src/api/BamConstants.h
@@ -126,10 +126,10 @@ const char BAM_DNA_PAD   = '*';
 
 // zlib & BGZF constants
 const char GZIP_ID1   = 31;
-const char GZIP_ID2   = 139;
+const char GZIP_ID2   = static_cast<char>(139);
 const char CM_DEFLATE = 8;
 const char FLG_FEXTRA = 4;
-const char OS_UNKNOWN = 255;
+const char OS_UNKNOWN = static_cast<char>(255);
 const char BGZF_XLEN  = 6;
 const char BGZF_ID1   = 66;
 const char BGZF_ID2   = 67;


### PR DESCRIPTION
* In future, the interfaces should probably be ported to uint8_t