### PR TITLE
Modernize CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,27 @@
 # top-level
 # ==========================
 
-# set project name
-project( BamTools )
+# CMake requirements
+cmake_minimum_required( VERSION 3.0 )
 
-# Cmake requirements
-cmake_minimum_required( VERSION 2.6.4 )
+# set project name
+project( BamTools LANGUAGES CXX )
+
+# on macOS, MACOSX_RPATH is enabled by default on more recent versions
+# of CMake. Disable this behaviour, and let user enable it if need be.
+cmake_policy( SET CMP0042 OLD )
+
+# Set Release type for builds where CMAKE_BUILD_TYPE is unset
+# This is usually a good default as this implictly enables
+#
+#   CXXFLAGS = -O3 -DNDEBUG
+#
+if( NOT CMAKE_BUILD_TYPE )
+    set( CMAKE_BUILD_TYPE "Release" )
+endif()
+
+# Adhere to GNU filesystem layout conventions
+include( GNUInstallDirs )
 
 # Force the build directory to be different from source directory
 macro( ENSURE_OUT_OF_SOURCE_BUILD MSG )
@@ -34,14 +50,9 @@ set( BamTools_VERSION_MAJOR 2 )
 set( BamTools_VERSION_MINOR 4 )
 set( BamTools_VERSION_BUILD 1 )
 
-# set our library and executable destination dirs
-set( EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin" )
-set( LIBRARY_OUTPUT_PATH    "${CMAKE_SOURCE_DIR}/lib" )
-
-# define compiler flags for all code
-set( CMAKE_BUILD_TYPE Release )
-set( CMAKE_CXX_FLAGS_RELEASE "-std=c++98 ${CMAKE_CXX_FLAGS_RELEASE}" )
-add_definitions( -Wall -D_FILE_OFFSET_BITS=64 )
+# define compiler flags for all code, copied from Autoconf's AC_SYS_LARGEFILE
+add_definitions( -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE )
+add_compile_options( -Wall )
 
 # -----------------------------------------------
 # handle platform-/environment-specific defines

--- a/src/ExportHeader.cmake
+++ b/src/ExportHeader.cmake
@@ -21,7 +21,7 @@ function( ExportHeader MODULE FILE DEST )
         "${CMAKE_SOURCE_DIR}/include/${DEST}/${FILENAME}" )
 
     # make sure files are properly 'installed'
-    install( FILES "${FILE}" DESTINATION "include/bamtools/${DEST}" )
+    install( FILES "${FILE}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/bamtools/${DEST}" )
 
 endfunction( ExportHeader )
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories( ${BamTools_SOURCE_DIR}/src )
 
 # add compiler definitions 
 add_definitions( -DBAMTOOLS_API_LIBRARY ) # (for proper exporting of library symbols)
-add_definitions( -fPIC ) # (attempt to force PIC compiling on CentOS, not being set on shared libs by CMake)
 
 # fetch all internal source files
 add_subdirectory( internal )
@@ -54,8 +53,8 @@ target_link_libraries( BamTools        ${APILibs} )
 target_link_libraries( BamTools-static ${APILibs} )
 
 # set library install destinations
-install( TARGETS BamTools        LIBRARY DESTINATION "lib/bamtools" RUNTIME DESTINATION "bin")
-install( TARGETS BamTools-static ARCHIVE DESTINATION "lib/bamtools")
+install( TARGETS BamTools        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" )
+install( TARGETS BamTools-static ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" )
 
 # export API headers
 include(../ExportHeader.cmake)

--- a/src/third_party/jsoncpp/CMakeLists.txt
+++ b/src/third_party/jsoncpp/CMakeLists.txt
@@ -7,7 +7,6 @@
 
 # add compiler definitions 
 add_definitions( -DBAMTOOLS_JSONCPP_LIBRARY ) # (for proper exporting of library symbols)
-add_definitions( -fPIC ) # (attempt to force PIC compiling on CentOS, not being set on shared libs by CMake)
 
 # create jsoncpp library
 add_library( jsoncpp STATIC

--- a/src/toolkit/CMakeLists.txt
+++ b/src/toolkit/CMakeLists.txt
@@ -41,4 +41,4 @@ configure_file( bamtools_version.h.in ${BamTools_SOURCE_DIR}/src/toolkit/bamtool
 target_link_libraries( bamtools_cmd BamTools BamTools-utils jsoncpp )
 
 # set application install destinations
-install( TARGETS bamtools_cmd DESTINATION "bin")
+install( TARGETS bamtools_cmd DESTINATION "${CMAKE_INSTALL_BINDIR}" )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -8,9 +8,8 @@
 # list include paths
 include_directories( ${BamTools_SOURCE_DIR}/src/api )
 
-# add compiler definitions 
+# add compiler definitions
 add_definitions( -DBAMTOOLS_UTILS_LIBRARY ) # (for proper exporting of library symbols)
-add_definitions( -fPIC ) # (attempt to force PIC compiling on CentOS, not being set on shared libs by CMake)
 
 # create BamTools utils library
 add_library( BamTools-utils STATIC


### PR DESCRIPTION
* Use 'GNUInstallDirs' to be able to set all paths and adhere
  to GNU coding conventions for the defaults
* Do not use -fPIC for static archives. This places an undue
  burden on certain architectures that suffer from register
  pressure, such as x86
* Remove hard coding C++98 into the build system, this is
  problematic on many levels, as it makes interfacing with the
  library cumbersome from C++11 and above code
* Set CMAKE_BUILD_TYPE to "Release" if not specified