### PR TITLE
Add pkg-config file for reverse dependencies of BamTools

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,3 +14,7 @@ add_subdirectory( utils )
 include( ExportHeader.cmake )
 set( SharedIncludeDir "shared" )
 ExportHeader( SharedHeaders shared/bamtools_global.h ${SharedIncludeDir} )
+
+# configure and install pkg-config file
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/bamtools.pc.in ${CMAKE_CURRENT_BINARY_DIR}/bamtools-1.pc @ONLY )
+install( FILES ${CMAKE_CURRENT_BINARY_DIR}/bamtools-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )

--- a/src/bamtools.pc.in
+++ b/src/bamtools.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: BamTools
+Description: BamTools is a C++ library for reading and manipulating BAM files
+Version: @BamTools_VERSION_MAJOR@.@BamTools_VERSION_MINOR@.@BamTools_VERSION_BUILD@
+
+Libs: -L${libdir} -lbamtools
+Cflags: -I${includedir}


### PR DESCRIPTION
* pkg-config is the _de facto_ standard tool to discover header
  locations and linker flags, instead of having to guess them.
* The .pc file is API versioned, in order to make it forward
  compatible with future versions of bamtools that break the API.
  The allows for a parallel installation of two otherwise
  incompatible bamtools libraries. See also:
    https://tecnocode.co.uk/2014/12/09/a-checklist-for-writing-pkg-config-files/
    https://developer.gnome.org/programming-guidelines/stable/parallel-installability.html.en