### PR TITLE
Employ idiomatic CMake option BUILD_SHARED_LIBS for switching library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ add_compile_options( -Wall )
 # -----------------------------------------------
 # handle platform-/environment-specific defines
 
+# By default build bamtools as a static library
+# Most users will prefer static libraries, distributions
+# can always switch the standard CMake variable over to ON.
+set( BUILD_SHARED_LIBS OFF CACHE BOOL "Build all libraries as shared" )
+
 # If planning to run in Node.js environment, run:
 # cmake -DEnableNodeJS=true
 if( EnableNodeJS )

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -30,18 +30,6 @@ set( BamToolsAPISources
         ${InternalSources}
 )
 
-# create main BamTools API shared library
-add_library( BamTools SHARED ${BamToolsAPISources} )
-set_target_properties( BamTools PROPERTIES
-                       SOVERSION "2.4.1"
-                       OUTPUT_NAME "bamtools" )
-
-# create main BamTools API static library
-add_library( BamTools-static STATIC ${BamToolsAPISources} )
-set_target_properties( BamTools-static PROPERTIES 
-                       OUTPUT_NAME "bamtools" 
-                       PREFIX "lib" )
-
 # link libraries automatically with zlib (and Winsock2, if applicable)
 if( WIN32 )
     set( APILibs z ws2_32 )
@@ -49,12 +37,18 @@ else()
     set( APILibs z )
 endif()
 
-target_link_libraries( BamTools        ${APILibs} )
-target_link_libraries( BamTools-static ${APILibs} )
-
-# set library install destinations
-install( TARGETS BamTools        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" )
-install( TARGETS BamTools-static ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" )
+# create main BamTools API library
+add_library( BamTools ${BamToolsAPISources} )
+# The SONAME is bumped on every version increment
+# as Bamtools does not yet guarantee a stable ABI
+set_target_properties( BamTools PROPERTIES
+                       SOVERSION "${BamTools_VERSION_MAJOR}.${BamTools_VERSION_MINOR}.${BamTools_VERSION_BUILD}"
+                       OUTPUT_NAME "bamtools" )
+target_link_libraries( BamTools ${APILibs} )
+install( TARGETS BamTools
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" )
 
 # export API headers
 include(../ExportHeader.cmake)

--- a/src/third_party/jsoncpp/CMakeLists.txt
+++ b/src/third_party/jsoncpp/CMakeLists.txt
@@ -18,3 +18,6 @@ set_target_properties( jsoncpp PROPERTIES
                        OUTPUT_NAME jsoncpp
                        PREFIX "lib"
                      )
+set_property( TARGET jsoncpp
+              PROPERTY position_independent_code ${BUILD_SHARED_LIBS}
+            )

--- a/src/toolkit/CMakeLists.txt
+++ b/src/toolkit/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable( bamtools_cmd
 
 # set BamTools application properties
 set_target_properties( bamtools_cmd PROPERTIES
-                       VERSION  2.4.1
                        OUTPUT_NAME "bamtools"
                      )
 # make version info available in application


### PR DESCRIPTION
* Like bundled libraries, many distributions do not build static
  libraries as they make security handling harder. The default is
  still to build the static library, but it can be switched now
  using the CMake standard variable `BUILD_SHARED_LIBS`.