### PR TITLE
Remove `using namespace std`

### DIFF
--- a/src/api/BamAlignment.cpp
+++ b/src/api/BamAlignment.cpp
@@ -10,7 +10,6 @@
 #include "api/BamAlignment.h"
 #include "api/BamConstants.h"
 using namespace BamTools;
-using namespace std;
 
 /*! \class BamTools::BamAlignment
     \brief The main BAM alignment data structure.
@@ -196,8 +195,8 @@ bool BamAlignment::BuildCharData(void) {
 
         // iterate over CigarOps
         int k = 0;
-        vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
-        vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
+        std::vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
+        std::vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
         for ( ; cigarIter != cigarEnd; ++cigarIter ) {
             const CigarOp& op = (*cigarIter);
 
@@ -238,7 +237,7 @@ bool BamAlignment::BuildCharData(void) {
 
                 // invalid CIGAR op-code
                 default:
-                    const string message = string("invalid CIGAR operation type: ") + op.Type;
+                    const std::string message = std::string("invalid CIGAR operation type: ") + op.Type;
                     SetErrorString("BamAlignment::BuildCharData", message);
                     return false;
             }
@@ -323,7 +322,7 @@ bool BamAlignment::BuildCharData(void) {
                                     i += sizeof(uint32_t);
                                     break;
                                 default:
-                                    const string message = string("invalid binary array type: ") + arrayType;
+                                    const std::string message = std::string("invalid binary array type: ") + arrayType;
                                     SetErrorString("BamAlignment::BuildCharData", message);
                                     return false;
                             }
@@ -334,7 +333,7 @@ bool BamAlignment::BuildCharData(void) {
 
                     // invalid tag type-code
                     default :
-                        const string message = string("invalid tag type: ") + type;
+                        const std::string message = std::string("invalid tag type: ") + type;
                         SetErrorString("BamAlignment::BuildCharData", message);
                         return false;
                 }
@@ -481,8 +480,8 @@ int BamAlignment::GetEndPosition(bool usePadded, bool closedInterval) const {
     int alignEnd = Position;
 
     // iterate over cigar operations
-    vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
-    vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
+    std::vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
+    std::vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
     for ( ; cigarIter != cigarEnd; ++cigarIter) {
         const CigarOp& op = (*cigarIter);
 
@@ -542,9 +541,9 @@ std::string BamAlignment::GetErrorString(void) const {
 
     \return \c true if any soft clips were found in the alignment
 */
-bool BamAlignment::GetSoftClips(vector<int>& clipSizes,
-                                vector<int>& readPositions,
-                                vector<int>& genomePositions,
+bool BamAlignment::GetSoftClips(std::vector<int>& clipSizes,
+                                std::vector<int>& readPositions,
+                                std::vector<int>& genomePositions,
                                 bool usePadded) const
 {
     // initialize positions & flags
@@ -554,8 +553,8 @@ bool BamAlignment::GetSoftClips(vector<int>& clipSizes,
     bool firstCigarOp  = true;
 
     // iterate over cigar operations
-    vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
-    vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
+    std::vector<CigarOp>::const_iterator cigarIter = CigarData.begin();
+    std::vector<CigarOp>::const_iterator cigarEnd  = CigarData.end();
     for ( ; cigarIter != cigarEnd; ++cigarIter) {
         const CigarOp& op = (*cigarIter);
 
@@ -708,7 +707,7 @@ bool BamAlignment::GetTagType(const std::string& tag, char& type) const {
 
         // unknown tag type
         default:
-            const string message = string("invalid tag type: ") + type;
+            const std::string message = std::string("invalid tag type: ") + type;
             SetErrorString("BamAlignment::GetTagType", message);
             return false;
     }
@@ -887,7 +886,7 @@ void BamAlignment::RemoveTag(const std::string& tag) {
     \param[in] what  description of error
 */
 void BamAlignment::SetErrorString(const std::string& where, const std::string& what) const {
-    static const string SEPARATOR = ": ";
+    static const std::string SEPARATOR(": ");
     ErrorString = where + SEPARATOR + what;
 }
 
@@ -1061,7 +1060,7 @@ bool BamAlignment::SkipToNextTag(const char storageType,
                     bytesToSkip = numElements*sizeof(uint32_t);
                     break;
                 default:
-                    const string message = string("invalid binary array type: ") + arrayType;
+                    const std::string message = std::string("invalid binary array type: ") + arrayType;
                     SetErrorString("BamAlignment::SkipToNextTag", message);
                     return false;
             }
@@ -1073,7 +1072,7 @@ bool BamAlignment::SkipToNextTag(const char storageType,
         }
 
         default:
-            const string message = string("invalid tag type: ") + storageType;
+            const std::string message = std::string("invalid tag type: ") + storageType;
             SetErrorString("BamAlignment::SkipToNextTag", message);
             return false;
     }

--- a/src/api/BamMultiReader.cpp
+++ b/src/api/BamMultiReader.cpp
@@ -18,7 +18,6 @@ using namespace BamTools;
 
 #include <string>
 #include <vector>
-using namespace std;
 
 /*! \class BamTools::BamMultiReader
     \brief Convenience class for reading multiple BAM files.

--- a/src/api/BamReader.cpp
+++ b/src/api/BamReader.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 #include <iterator>
 #include <string>
 #include <vector>
-using namespace std;
 
 /*! \class BamTools::BamReader
     \brief Provides read access to BAM files.
@@ -85,7 +84,7 @@ const SamHeader& BamReader::GetConstSamHeader(void) const {
 
     \return error description
 */
-string BamReader::GetErrorString(void) const {
+std::string BamReader::GetErrorString(void) const {
     return d->GetErrorString();
 }
 

--- a/src/api/BamWriter.cpp
+++ b/src/api/BamWriter.cpp
@@ -13,7 +13,6 @@
 #include "api/internal/bam/BamWriter_p.h"
 using namespace BamTools;
 using namespace BamTools::Internal;
-using namespace std;
 
 /*! \class BamTools::BamWriter
     \brief Provides write access for generating BAM files.

--- a/src/api/SamHeader.cpp
+++ b/src/api/SamHeader.cpp
@@ -15,7 +15,6 @@
 #include "api/internal/sam/SamHeaderValidator_p.h"
 using namespace BamTools;
 using namespace BamTools::Internal;
-using namespace std;
 
 /*! \struct BamTools::SamHeader
     \brief Represents the SAM-formatted text header that is part of the BAM file header.
@@ -193,7 +192,7 @@ bool SamHeader::IsValid(bool verbose) const {
 
         // or catch in local error string
         else {
-            stringstream errorStream("");
+            std::stringstream errorStream;
             validator.PrintMessages(errorStream);
             m_errorString = errorStream.str();
         }
@@ -232,7 +231,7 @@ void SamHeader::SetHeaderText(const std::string& headerText) {
 
     \return SAM-formatted header text
 */
-string SamHeader::ToString(void) const {
+std::string SamHeader::ToString(void) const {
     SamFormatPrinter printer(*this);
     return printer.ToString();
 }

--- a/src/api/SamProgram.cpp
+++ b/src/api/SamProgram.cpp
@@ -9,7 +9,6 @@
 
 #include "api/SamProgram.h"
 using namespace BamTools;
-using namespace std;
 
 /*! \struct BamTools::SamProgram
     \brief Represents a SAM program record.

--- a/src/api/SamProgramChain.cpp
+++ b/src/api/SamProgramChain.cpp
@@ -13,7 +13,6 @@ using namespace BamTools;
 #include <algorithm>
 #include <iostream>
 #include <cstdlib>
-using namespace std;
 
 /*! \class BamTools::SamProgramChain
     \brief Sorted container "chain" of SamProgram records.
@@ -79,8 +78,8 @@ void SamProgramChain::Add(SamProgram& program) {
     \sa Add()
 */
 void SamProgramChain::Add(std::vector<SamProgram>& programs) {
-    vector<SamProgram>::iterator pgIter = programs.begin();
-    vector<SamProgram>::iterator pgEnd  = programs.end();
+    std::vector<SamProgram>::iterator pgIter = programs.begin();
+    std::vector<SamProgram>::iterator pgEnd  = programs.end();
     for ( ; pgIter != pgEnd; ++pgIter )
         Add(*pgIter);
 }
@@ -189,8 +188,8 @@ SamProgram& SamProgramChain::First(void) {
     }
 
     // otherwise error
-    cerr << "SamProgramChain::First: could not find any record without a PP tag" << endl;
-    exit(1);
+    std::cerr << "SamProgramChain::First: could not find any record without a PP tag" << std::endl;
+    std::exit(EXIT_FAILURE);
 }
 
 /*! \fn const SamProgram& SamProgramChain::First(void) const
@@ -216,8 +215,8 @@ const SamProgram& SamProgramChain::First(void) const {
     }
 
     // otherwise error
-    cerr << "SamProgramChain::First: could not find any record without a PP tag" << endl;
-    exit(1);
+    std::cerr << "SamProgramChain::First: could not find any record without a PP tag" << std::endl;
+    std::exit(EXIT_FAILURE);
 }
 
 /*! \fn int SamProgramChain::IndexOf(const std::string& programId) const
@@ -265,8 +264,8 @@ SamProgram& SamProgramChain::Last(void) {
     }
 
     // otherwise error
-    cerr << "SamProgramChain::Last: could not determine last record" << endl;
-    exit(1);
+    std::cerr << "SamProgramChain::Last: could not determine last record" << std::endl;
+    std::exit(EXIT_FAILURE);
 }
 
 /*! \fn const SamProgram& SamProgramChain::Last(void) const
@@ -291,8 +290,8 @@ const SamProgram& SamProgramChain::Last(void) const {
     }
 
     // otherwise error
-    cerr << "SamProgramChain::Last: could not determine last record" << endl;
-    exit(1);
+    std::cerr << "SamProgramChain::Last: could not determine last record" << std::endl;
+    std::exit(EXIT_FAILURE);
 }
 
 /*! \fn const std::string SamProgramChain::NextIdFor(const std::string& programId) const
@@ -317,7 +316,7 @@ const std::string SamProgramChain::NextIdFor(const std::string& programId) const
     }
 
     // none found
-    return string();
+    return std::string();
 }
 
 /*! \fn int SamProgramChain::Size(void) const
@@ -345,8 +344,8 @@ SamProgram& SamProgramChain::operator[](const std::string& programId) {
 
     // if record not found
     if ( index == (int)m_data.size() ) {
-        cerr << "SamProgramChain::operator[] - unknown programId: " << programId << endl;
-        exit(1);
+        std::cerr << "SamProgramChain::operator[] - unknown programId: " << programId << std::endl;
+        std::exit(EXIT_FAILURE);
     }
 
     // otherwise return program record at index

--- a/src/api/SamReadGroup.cpp
+++ b/src/api/SamReadGroup.cpp
@@ -9,7 +9,6 @@
 
 #include "api/SamReadGroup.h"
 using namespace BamTools;
-using namespace std;
 
 /*! \struct BamTools::SamReadGroup
     \brief Represents a SAM read group entry.

--- a/src/api/SamReadGroupDictionary.cpp
+++ b/src/api/SamReadGroupDictionary.cpp
@@ -11,7 +11,6 @@
 using namespace BamTools;
 
 #include <iostream>
-using namespace std;
 
 /*! \class BamTools::SamReadGroupDictionary
     \brief Container of SamReadGroup entries.
@@ -87,8 +86,8 @@ void SamReadGroupDictionary::Add(const SamReadGroupDictionary& readGroups) {
     \sa Add()
 */
 void SamReadGroupDictionary::Add(const std::vector<SamReadGroup>& readGroups) {
-    vector<SamReadGroup>::const_iterator rgIter = readGroups.begin();
-    vector<SamReadGroup>::const_iterator rgEnd  = readGroups.end();
+    std::vector<SamReadGroup>::const_iterator rgIter = readGroups.begin();
+    std::vector<SamReadGroup>::const_iterator rgEnd  = readGroups.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Add(*rgIter);
 }
@@ -102,8 +101,8 @@ void SamReadGroupDictionary::Add(const std::vector<SamReadGroup>& readGroups) {
     \sa Add()
 */
 void SamReadGroupDictionary::Add(const std::vector<std::string>& readGroupIds) {
-    vector<string>::const_iterator rgIter = readGroupIds.begin();
-    vector<string>::const_iterator rgEnd  = readGroupIds.end();
+    std::vector<std::string>::const_iterator rgIter = readGroupIds.begin();
+    std::vector<std::string>::const_iterator rgEnd  = readGroupIds.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Add(*rgIter);
 }
@@ -245,8 +244,8 @@ void SamReadGroupDictionary::Remove(const std::string& readGroupId) {
     \sa Remove()
 */
 void SamReadGroupDictionary::Remove(const std::vector<SamReadGroup>& readGroups) {
-    vector<SamReadGroup>::const_iterator rgIter = readGroups.begin();
-    vector<SamReadGroup>::const_iterator rgEnd  = readGroups.end();
+    std::vector<SamReadGroup>::const_iterator rgIter = readGroups.begin();
+    std::vector<SamReadGroup>::const_iterator rgEnd  = readGroups.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Remove(*rgIter);
 }
@@ -260,8 +259,8 @@ void SamReadGroupDictionary::Remove(const std::vector<SamReadGroup>& readGroups)
     \sa Remove()
 */
 void SamReadGroupDictionary::Remove(const std::vector<std::string>& readGroupIds) {
-    vector<string>::const_iterator rgIter = readGroupIds.begin();
-    vector<string>::const_iterator rgEnd  = readGroupIds.end();
+    std::vector<std::string>::const_iterator rgIter = readGroupIds.begin();
+    std::vector<std::string>::const_iterator rgEnd  = readGroupIds.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Remove(*rgIter);
 }

--- a/src/api/SamSequence.cpp
+++ b/src/api/SamSequence.cpp
@@ -10,7 +10,6 @@
 #include "api/SamSequence.h"
 #include <sstream>
 using namespace BamTools;
-using namespace std;
 
 /*! \struct BamTools::SamSequence
     \brief Represents a SAM sequence entry.
@@ -68,7 +67,7 @@ SamSequence::SamSequence(const std::string& name,
     , Species("")
     , URI("")
 {
-    stringstream s("");
+    std::stringstream s;
     s << length;
     Length = s.str();
 }

--- a/src/api/SamSequenceDictionary.cpp
+++ b/src/api/SamSequenceDictionary.cpp
@@ -11,7 +11,6 @@
 using namespace BamTools;
 
 #include <iostream>
-using namespace std;
 
 /*! \class BamTools::SamSequenceDictionary
     \brief Container of SamSequence entries.
@@ -88,8 +87,8 @@ void SamSequenceDictionary::Add(const SamSequenceDictionary& sequences) {
     \sa Add()
 */
 void SamSequenceDictionary::Add(const std::vector<SamSequence>& sequences) {
-    vector<SamSequence>::const_iterator seqIter = sequences.begin();
-    vector<SamSequence>::const_iterator seqEnd  = sequences.end();
+    std::vector<SamSequence>::const_iterator seqIter = sequences.begin();
+    std::vector<SamSequence>::const_iterator seqEnd  = sequences.end();
     for ( ; seqIter!= seqEnd; ++seqIter )
         Add(*seqIter);
 }
@@ -103,10 +102,10 @@ void SamSequenceDictionary::Add(const std::vector<SamSequence>& sequences) {
     \sa Add()
 */
 void SamSequenceDictionary::Add(const std::map<std::string, int>& sequenceMap) {
-    map<string, int>::const_iterator seqIter = sequenceMap.begin();
-    map<string, int>::const_iterator seqEnd  = sequenceMap.end();
+    std::map<std::string, int>::const_iterator seqIter = sequenceMap.begin();
+    std::map<std::string, int>::const_iterator seqEnd  = sequenceMap.end();
     for ( ; seqIter != seqEnd; ++seqIter ) {
-        const string& name = (*seqIter).first;
+        const std::string& name = (*seqIter).first;
         const int& length = (*seqIter).second;
         Add( SamSequence(name, length) );
     }
@@ -249,8 +248,8 @@ void SamSequenceDictionary::Remove(const std::string& sequenceName) {
     \sa Remove()
 */
 void SamSequenceDictionary::Remove(const std::vector<SamSequence>& sequences) {
-    vector<SamSequence>::const_iterator rgIter = sequences.begin();
-    vector<SamSequence>::const_iterator rgEnd  = sequences.end();
+    std::vector<SamSequence>::const_iterator rgIter = sequences.begin();
+    std::vector<SamSequence>::const_iterator rgEnd  = sequences.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Remove(*rgIter);
 }
@@ -264,8 +263,8 @@ void SamSequenceDictionary::Remove(const std::vector<SamSequence>& sequences) {
     \sa Remove()
 */
 void SamSequenceDictionary::Remove(const std::vector<std::string>& sequenceNames) {
-    vector<string>::const_iterator rgIter = sequenceNames.begin();
-    vector<string>::const_iterator rgEnd  = sequenceNames.end();
+    std::vector<std::string>::const_iterator rgIter = sequenceNames.begin();
+    std::vector<std::string>::const_iterator rgEnd  = sequenceNames.end();
     for ( ; rgIter!= rgEnd; ++rgIter )
         Remove(*rgIter);
 }

--- a/src/api/internal/bam/BamHeader_p.cpp
+++ b/src/api/internal/bam/BamHeader_p.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 
 #include <cstdlib>
 #include <cstring>
-using namespace std;
 
 // ------------------------
 // static utility methods
@@ -105,7 +104,7 @@ void BamHeader::ReadHeaderText(BgzfStream* stream, const uint32_t& length) {
 
     // otherwise, text was read OK
     // store & cleanup
-    m_header.SetHeaderText( (string)((const char*)headerText) );
+    m_header.SetHeaderText( static_cast<std::string>((const char*)headerText) );
     free(headerText);
 }
 
@@ -120,6 +119,6 @@ SamHeader BamHeader::ToSamHeader(void) const {
 }
 
 // returns SAM-formatted string of header data
-string BamHeader::ToString(void) const {
+std::string BamHeader::ToString(void) const {
     return m_header.ToString();
 }

--- a/src/api/internal/bam/BamMultiReader_p.cpp
+++ b/src/api/internal/bam/BamMultiReader_p.cpp
@@ -20,7 +20,6 @@ using namespace BamTools::Internal;
 #include <iostream>
 #include <iterator>
 #include <sstream>
-using namespace std;
 
 // ctor
 BamMultiReaderPrivate::BamMultiReaderPrivate(void)
@@ -42,45 +41,45 @@ bool BamMultiReaderPrivate::Close(void) {
     if ( CloseFiles(Filenames()) )
         return true;
     else {
-        const string currentError = m_errorString;
-        const string message = string("error encountered while closing all files: \n\t") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("error encountered while closing all files: \n\t") + currentError;
         SetErrorString("BamMultiReader::Close", message);
         return false;
     }
 }
 
 // close requested BAM file
-bool BamMultiReaderPrivate::CloseFile(const string& filename) {
+bool BamMultiReaderPrivate::CloseFile(const std::string& filename) {
 
     m_errorString.clear();
 
-    vector<string> filenames(1, filename);
+    std::vector<std::string> filenames(1, filename);
     if ( CloseFiles(filenames) )
         return true;
     else {
-        const string currentError = m_errorString;
-        const string message = string("error while closing file: ") + filename + "\n" + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("error while closing file: ") + filename + "\n" + currentError;
         SetErrorString("BamMultiReader::CloseFile", message);
         return false;
     }
 }
 
 // close requested BAM files
-bool BamMultiReaderPrivate::CloseFiles(const vector<string>& filenames) {
+bool BamMultiReaderPrivate::CloseFiles(const std::vector<std::string>& filenames) {
 
     bool errorsEncountered = false;
     m_errorString.clear();
 
     // iterate over filenames
-    vector<string>::const_iterator filesIter = filenames.begin();
-    vector<string>::const_iterator filesEnd  = filenames.end();
+    std::vector<std::string>::const_iterator filesIter = filenames.begin();
+    std::vector<std::string>::const_iterator filesEnd  = filenames.end();
     for ( ; filesIter != filesEnd; ++filesIter ) {
-        const string& filename = (*filesIter);
+        const std::string& filename = (*filesIter);
         if ( filename.empty() ) continue;
 
         // iterate over readers
-        vector<MergeItem>::iterator readerIter = m_readers.begin();
-        vector<MergeItem>::iterator readerEnd  = m_readers.end();
+        std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+        std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
         for ( ; readerIter != readerEnd; ++readerIter ) {
             MergeItem& item = (*readerIter);
             BamReader* reader = item.Reader;
@@ -143,8 +142,8 @@ bool BamMultiReaderPrivate::CreateIndexes(const BamIndex::IndexType& type) {
     m_errorString.clear();
 
     // iterate over readers
-    vector<MergeItem>::iterator itemIter = m_readers.begin();
-    vector<MergeItem>::iterator itemEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator itemIter = m_readers.begin();
+    std::vector<MergeItem>::iterator itemEnd  = m_readers.end();
     for ( ; itemIter != itemEnd; ++itemIter ) {
         MergeItem& item = (*itemIter);
         BamReader* reader = item.Reader;
@@ -163,8 +162,8 @@ bool BamMultiReaderPrivate::CreateIndexes(const BamIndex::IndexType& type) {
 
     // check for errors encountered before returning success/fail
     if ( errorsEncountered ) {
-        const string currentError = m_errorString;
-        const string message = string("error while creating index files: ") + "\n" + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("error while creating index files: \n") + currentError;
         SetErrorString("BamMultiReader::CreateIndexes", message);
         return false;
     } else
@@ -213,22 +212,22 @@ IMultiMerger* BamMultiReaderPrivate::CreateAlignmentCache(void) {
     }
 }
 
-const vector<string> BamMultiReaderPrivate::Filenames(void) const {
+const std::vector<std::string> BamMultiReaderPrivate::Filenames(void) const {
 
     // init filename container
-    vector<string> filenames;
+    std::vector<std::string> filenames;
     filenames.reserve( m_readers.size() );
 
     // iterate over readers
-    vector<MergeItem>::const_iterator itemIter = m_readers.begin();
-    vector<MergeItem>::const_iterator itemEnd  = m_readers.end();
+    std::vector<MergeItem>::const_iterator itemIter = m_readers.begin();
+    std::vector<MergeItem>::const_iterator itemEnd  = m_readers.end();
     for ( ; itemIter != itemEnd; ++itemIter ) {
         const MergeItem& item = (*itemIter);
         const BamReader* reader = item.Reader;
         if ( reader == 0 ) continue;
 
         // store filename if not empty
-        const string& filename = reader->GetFilename();
+        const std::string& filename = reader->GetFilename();
         if ( !filename.empty() )
             filenames.push_back(filename);
     }
@@ -237,17 +236,17 @@ const vector<string> BamMultiReaderPrivate::Filenames(void) const {
     return filenames;
 }
 
-string BamMultiReaderPrivate::GetErrorString(void) const {
+std::string BamMultiReaderPrivate::GetErrorString(void) const {
     return m_errorString;
 }
 
 SamHeader BamMultiReaderPrivate::GetHeader(void) const {
-    const string& text = GetHeaderText();
+    const std::string& text = GetHeaderText();
     return SamHeader(text);
 }
 
 // makes a virtual, unified header for all the bam files in the multireader
-string BamMultiReaderPrivate::GetHeaderText(void) const {
+std::string BamMultiReaderPrivate::GetHeaderText(void) const {
 
     // N.B. - right now, simply copies all header data from first BAM,
     //        and then appends RG's from other BAM files
@@ -255,12 +254,12 @@ string BamMultiReaderPrivate::GetHeaderText(void) const {
 
     // if no readers open
     const size_t numReaders = m_readers.size();
-    if ( numReaders == 0 ) return string();
+    if ( numReaders == 0 ) return std::string();
 
     // retrieve first reader's header
     const MergeItem& firstItem = m_readers.front();
     const BamReader* reader = firstItem.Reader;
-    if ( reader == 0 ) return string();
+    if ( reader == 0 ) return std::string();
     SamHeader mergedHeader = reader->GetHeader();
 
     // iterate over any remaining readers (skipping the first)
@@ -336,7 +335,7 @@ const RefVector BamMultiReaderPrivate::GetReferenceData(void) const {
 }
 
 // returns refID from reference name
-int BamMultiReaderPrivate::GetReferenceID(const string& refName) const {
+int BamMultiReaderPrivate::GetReferenceID(const std::string& refName) const {
 
     // handle empty multireader
     if ( m_readers.empty() ) return -1;
@@ -361,8 +360,8 @@ bool BamMultiReaderPrivate::HasIndexes(void) const {
     bool result = true;
 
     // iterate over readers
-    vector<MergeItem>::const_iterator readerIter = m_readers.begin();
-    vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::const_iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         const MergeItem& item = (*readerIter);
         const BamReader* reader = item.Reader;
@@ -379,8 +378,8 @@ bool BamMultiReaderPrivate::HasIndexes(void) const {
 bool BamMultiReaderPrivate::HasOpenReaders(void) {
 
     // iterate over readers
-    vector<MergeItem>::const_iterator readerIter = m_readers.begin();
-    vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::const_iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         const MergeItem& item = (*readerIter);
         const BamReader* reader = item.Reader;
@@ -403,8 +402,8 @@ bool BamMultiReaderPrivate::Jump(int refID, int position) {
     // UpdateAlignments(), and continue.
 
     // iterate over readers
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -425,8 +424,8 @@ bool BamMultiReaderPrivate::LocateIndexes(const BamIndex::IndexType& preferredTy
     m_errorString.clear();
 
     // iterate over readers
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -445,8 +444,8 @@ bool BamMultiReaderPrivate::LocateIndexes(const BamIndex::IndexType& preferredTy
 
     // check for errors encountered before returning success/fail
     if ( errorsEncountered ) {
-        const string currentError = m_errorString;
-        const string message = string("error while locating index files: ") + "\n" + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("error while locating index files: \n") + currentError;
         SetErrorString("BamMultiReader::LocatingIndexes", message);
         return false;
     } else
@@ -454,24 +453,24 @@ bool BamMultiReaderPrivate::LocateIndexes(const BamIndex::IndexType& preferredTy
 }
 
 // opens BAM files
-bool BamMultiReaderPrivate::Open(const vector<string>& filenames) {
+bool BamMultiReaderPrivate::Open(const std::vector<std::string>& filenames) {
 
     m_errorString.clear();
 
     // put all current readers back at beginning (refreshes alignment cache)
     if ( !Rewind() ) {
-        const string currentError = m_errorString;
-        const string message = string("unable to rewind existing readers: \n\t") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("unable to rewind existing readers: \n\t") + currentError;
         SetErrorString("BamMultiReader::Open", message);
         return false;
     }
 
     // iterate over filenames
     bool errorsEncountered = false;
-    vector<string>::const_iterator filenameIter = filenames.begin();
-    vector<string>::const_iterator filenameEnd  = filenames.end();
+    std::vector<std::string>::const_iterator filenameIter = filenames.begin();
+    std::vector<std::string>::const_iterator filenameEnd  = filenames.end();
     for ( ; filenameIter != filenameEnd; ++filenameIter ) {
-        const string& filename = (*filenameIter);
+        const std::string& filename = (*filenameIter);
         if ( filename.empty() ) continue;
 
         // attempt to open BamReader
@@ -485,7 +484,7 @@ bool BamMultiReaderPrivate::Open(const vector<string>& filenames) {
         // otherwise store error & clean up invalid reader
         else {
             m_errorString.append(1, '\t');
-            m_errorString += string("unable to open file: ") + filename;
+            m_errorString += std::string("unable to open file: ") + filename;
             m_errorString.append(1, '\n');
             errorsEncountered = true;
 
@@ -496,16 +495,16 @@ bool BamMultiReaderPrivate::Open(const vector<string>& filenames) {
 
     // check for errors while opening
     if ( errorsEncountered ) {
-        const string currentError = m_errorString;
-        const string message = string("unable to open all files: \t\n") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("unable to open all files: \t\n") + currentError;
         SetErrorString("BamMultiReader::Open", message);
         return false;
     }
 
     // check for BAM file consistency
     if ( !ValidateReaders() ) {
-        const string currentError = m_errorString;
-        const string message = string("unable to open inconsistent files: \t\n") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("unable to open inconsistent files: \t\n") + currentError;
         SetErrorString("BamMultiReader::Open", message);
         return false;
     }
@@ -515,18 +514,18 @@ bool BamMultiReaderPrivate::Open(const vector<string>& filenames) {
 }
 
 bool BamMultiReaderPrivate::OpenFile(const std::string& filename) {
-    vector<string> filenames(1, filename);
+    std::vector<std::string> filenames(1, filename);
     if ( Open(filenames) )
         return true;
     else {
-        const string currentError = m_errorString;
-        const string message = string("could not open file: ") + filename + "\n\t" + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("could not open file: ") + filename + "\n\t" + currentError;
         SetErrorString("BamMultiReader::OpenFile", message);
         return false;
     }
 }
 
-bool BamMultiReaderPrivate::OpenIndexes(const vector<string>& indexFilenames) {
+bool BamMultiReaderPrivate::OpenIndexes(const std::vector<std::string>& indexFilenames) {
 
     // TODO: This needs to be cleaner - should not assume same order.
     //       And either way, shouldn't start at first reader.  Should start at
@@ -534,7 +533,7 @@ bool BamMultiReaderPrivate::OpenIndexes(const vector<string>& indexFilenames) {
 
     // make sure same number of index filenames as readers
     if ( m_readers.size() != indexFilenames.size() ) {
-        const string message("size of index file list does not match current BAM file count");
+        const std::string message("size of index file list does not match current BAM file count");
         SetErrorString("BamMultiReader::OpenIndexes", message);
         return false;
     }
@@ -543,17 +542,17 @@ bool BamMultiReaderPrivate::OpenIndexes(const vector<string>& indexFilenames) {
     m_errorString.clear();
 
     // iterate over BamReaders
-    vector<string>::const_iterator indexFilenameIter = indexFilenames.begin();
-    vector<string>::const_iterator indexFilenameEnd  = indexFilenames.end();
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<std::string>::const_iterator indexFilenameIter = indexFilenames.begin();
+    std::vector<std::string>::const_iterator indexFilenameEnd  = indexFilenames.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
 
         // open index filename on reader
         if ( reader ) {
-            const string& indexFilename = (*indexFilenameIter);
+            const std::string& indexFilename = (*indexFilenameIter);
             if ( !reader->OpenIndex(indexFilename) ) {
                 m_errorString.append(1, '\t');
                 m_errorString += reader->GetErrorString();
@@ -569,8 +568,8 @@ bool BamMultiReaderPrivate::OpenIndexes(const vector<string>& indexFilenames) {
 
     // return success/fail
     if ( errorsEncountered ) {
-        const string currentError = m_errorString;
-        const string message = string("could not open all index files: \n\t") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("could not open all index files: \n\t") + currentError;
         SetErrorString("BamMultiReader::OpenIndexes", message);
         return false;
     } else
@@ -613,8 +612,8 @@ bool BamMultiReaderPrivate::Rewind(void) {
 
     // attempt to rewind files
     if ( !RewindReaders() ) {
-        const string currentError = m_errorString;
-        const string message = string("could not rewind readers: \n\t") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("could not rewind readers: \n\t") + currentError;
         SetErrorString("BamMultiReader::Rewind", message);
         return false;
     }
@@ -630,8 +629,8 @@ bool BamMultiReaderPrivate::RewindReaders(void) {
     bool errorsEncountered = false;
 
     // iterate over readers
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -668,7 +667,7 @@ bool BamMultiReaderPrivate::SetExplicitMergeOrder(BamMultiReader::MergeOrder ord
     m_mergeOrder = order;
 
     // remove any existing merger (storing any existing data sitting in the cache)
-    vector<MergeItem> currentCacheData;
+    std::vector<MergeItem> currentCacheData;
     if ( m_alignmentCache ) {        
         while ( !m_alignmentCache->IsEmpty() )
             currentCacheData.push_back( m_alignmentCache->TakeFirst() );
@@ -684,8 +683,8 @@ bool BamMultiReaderPrivate::SetExplicitMergeOrder(BamMultiReader::MergeOrder ord
     }
 
     // push current data onto new cache
-    vector<MergeItem>::const_iterator readerIter = currentCacheData.begin();
-    vector<MergeItem>::const_iterator readerEnd  = currentCacheData.end();
+    std::vector<MergeItem>::const_iterator readerIter = currentCacheData.begin();
+    std::vector<MergeItem>::const_iterator readerEnd  = currentCacheData.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         const MergeItem& item = (*readerIter);
         m_alignmentCache->Add(item);
@@ -695,8 +694,8 @@ bool BamMultiReaderPrivate::SetExplicitMergeOrder(BamMultiReader::MergeOrder ord
     return true;
 }
 
-void BamMultiReaderPrivate::SetErrorString(const string& where, const string& what) const {
-    static const string SEPARATOR = ": ";
+void BamMultiReaderPrivate::SetErrorString(const std::string& where, const std::string& what) const {
+    static const std::string SEPARATOR(": ");
     m_errorString = where + SEPARATOR + what;
 }
 
@@ -708,8 +707,8 @@ bool BamMultiReaderPrivate::SetRegion(const BamRegion& region) {
     // UpdateAlignments(), and continue.
 
     // iterate over alignments
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -739,8 +738,8 @@ bool BamMultiReaderPrivate::UpdateAlignmentCache(void) {
     m_alignmentCache->Clear();
 
     // iterate over readers
-    vector<MergeItem>::iterator readerIter = m_readers.begin();
-    vector<MergeItem>::iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -774,7 +773,7 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
 
     // retrieve first reader's header data
     const SamHeader& firstReaderHeader = firstReader->GetHeader();
-    const string& firstReaderSortOrder = firstReaderHeader.SortOrder;
+    const std::string& firstReaderSortOrder = firstReaderHeader.SortOrder;
 
     // retrieve first reader's reference data
     const RefVector& firstReaderRefData = firstReader->GetReferenceData();
@@ -782,8 +781,8 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
     const int firstReaderRefSize = firstReaderRefData.size();
 
     // iterate over all readers
-    vector<MergeItem>::const_iterator readerIter = m_readers.begin();
-    vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
+    std::vector<MergeItem>::const_iterator readerIter = m_readers.begin();
+    std::vector<MergeItem>::const_iterator readerEnd  = m_readers.end();
     for ( ; readerIter != readerEnd; ++readerIter ) {
         const MergeItem& item = (*readerIter);
         BamReader* reader = item.Reader;
@@ -791,11 +790,11 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
 
         // get current reader's header data
         const SamHeader& currentReaderHeader = reader->GetHeader();
-        const string& currentReaderSortOrder = currentReaderHeader.SortOrder;
+        const std::string& currentReaderSortOrder = currentReaderHeader.SortOrder;
 
         // check compatible sort order
         if ( currentReaderSortOrder != firstReaderSortOrder ) {
-            const string message = string("mismatched sort order in ") + reader->GetFilename() +
+            const std::string message = std::string("mismatched sort order in ") + reader->GetFilename() +
                                    ", expected " + firstReaderSortOrder +
                                    ", but found " + currentReaderSortOrder;
             SetErrorString("BamMultiReader::ValidateReaders", message);
@@ -816,7 +815,7 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
         if ( (currentReaderRefCount != firstReaderRefCount) ||
              (firstReaderRefSize    != currentReaderRefSize) )
         {
-            stringstream s("");
+            std::stringstream s;
             s << "mismatched reference count in " << reader->GetFilename()
               << ", expected " << firstReaderRefCount
               << ", but found " << currentReaderRefCount;
@@ -834,27 +833,27 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
             if ( (firstRef.RefName   != currentRef.RefName) ||
                  (firstRef.RefLength != currentRef.RefLength) )
             {
-                stringstream s("");
+                std::stringstream s;
                 s << "mismatched references found in" << reader->GetFilename()
-                  << "expected: " << endl;
+                  << "expected: " << std::endl;
 
                 // print first reader's reference data
                 RefVector::const_iterator refIter = firstReaderRefData.begin();
                 RefVector::const_iterator refEnd  = firstReaderRefData.end();
                 for ( ; refIter != refEnd; ++refIter ) {
                     const RefData& entry = (*refIter);
-                    stringstream s("");
-                    s << entry.RefName << " " << endl;
+                    std::stringstream s;
+                    s << entry.RefName << " " << std::endl;
                 }
 
-                s << "but found: " << endl;
+                s << "but found: " << std::endl;
 
                 // print current reader's reference data
                 refIter = currentReaderRefData.begin();
                 refEnd  = currentReaderRefData.end();
                 for ( ; refIter != refEnd; ++refIter ) {
                     const RefData& entry = (*refIter);
-                    s << entry.RefName << " " << entry.RefLength << endl;
+                    s << entry.RefName << " " << entry.RefLength << std::endl;
                 }
 
                 SetErrorString("BamMultiReader::ValidateReaders", s.str());

--- a/src/api/internal/bam/BamRandomAccessController_p.cpp
+++ b/src/api/internal/bam/BamRandomAccessController_p.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 
 #include <cassert>
 #include <sstream>
-using namespace std;
 
 BamRandomAccessController::BamRandomAccessController(void)
     : m_index(0)
@@ -159,7 +158,7 @@ bool BamRandomAccessController::CreateIndex(BamReaderPrivate* reader,
     // create new index of requested type
     BamIndex* newIndex = BamIndexFactory::CreateIndexOfType(type, reader);
     if ( newIndex == 0 ) {
-        stringstream s("");
+        std::stringstream s;
         s << "could not create index of type: " << type;
         SetErrorString("BamRandomAccessController::CreateIndex", s.str());
         return false;
@@ -167,8 +166,8 @@ bool BamRandomAccessController::CreateIndex(BamReaderPrivate* reader,
 
     // attempt to build index from current BamReader file
     if ( !newIndex->Create() ) {
-        const string indexError = newIndex->GetErrorString();
-        const string message = "could not create index: \n\t" + indexError;
+        const std::string indexError = newIndex->GetErrorString();
+        const std::string message = "could not create index: \n\t" + indexError;
         SetErrorString("BamRandomAccessController::CreateIndex", message);
         return false;
     }
@@ -178,7 +177,7 @@ bool BamRandomAccessController::CreateIndex(BamReaderPrivate* reader,
     return true;
 }
 
-string BamRandomAccessController::GetErrorString(void) const {
+std::string BamRandomAccessController::GetErrorString(void) const {
     return m_errorString;
 }
 
@@ -199,11 +198,11 @@ bool BamRandomAccessController::LocateIndex(BamReaderPrivate* reader,
 {
     // look up index filename, deferring to preferredType if possible
     assert(reader);
-    const string& indexFilename = BamIndexFactory::FindIndexFilename(reader->Filename(), preferredType);
+    const std::string& indexFilename = BamIndexFactory::FindIndexFilename(reader->Filename(), preferredType);
 
     // if no index file found (of any type)
     if ( indexFilename.empty() ) {
-        const string message = string("could not find index file for:") + reader->Filename();
+        const std::string message = std::string("could not find index file for:") + reader->Filename();
         SetErrorString("BamRandomAccessController::LocateIndex", message);
         return false;
     }
@@ -212,20 +211,20 @@ bool BamRandomAccessController::LocateIndex(BamReaderPrivate* reader,
     return OpenIndex(indexFilename, reader);
 }
 
-bool BamRandomAccessController::OpenIndex(const string& indexFilename, BamReaderPrivate* reader) {
+bool BamRandomAccessController::OpenIndex(const std::string& indexFilename, BamReaderPrivate* reader) {
 
     // attempt create new index of type based on filename
     BamIndex* index = BamIndexFactory::CreateIndexFromFilename(indexFilename, reader);
     if ( index == 0 ) {
-        const string message = string("could not open index file: ") + indexFilename;
+        const std::string message = std::string("could not open index file: ") + indexFilename;
         SetErrorString("BamRandomAccessController::OpenIndex", message);
         return false;
     }
 
     // attempt to load data from index file
     if ( !index->Load(indexFilename) ) {
-        const string indexError = index->GetErrorString();
-        const string message = string("could not load index data from file: ") + indexFilename +
+        const std::string indexError = index->GetErrorString();
+        const std::string message = std::string("could not load index data from file: ") + indexFilename +
                                "\n\t" + indexError;
         SetErrorString("BamRandomAccessController::OpenIndex", message);
         return false;
@@ -240,7 +239,7 @@ bool BamRandomAccessController::RegionHasAlignments(void) const {
     return m_hasAlignmentsInRegion;
 }
 
-void BamRandomAccessController::SetErrorString(const string& where, const string& what) {
+void BamRandomAccessController::SetErrorString(const std::string& where, const std::string& what) {
     m_errorString = where + ": " + what;
 }
 
@@ -279,8 +278,8 @@ bool BamRandomAccessController::SetRegion(const BamRegion& region, const int& re
     //    will not return data. BamMultiReader will still be able to successfully pull alignments
     //    from a region from other files even if this one has no data.
     if ( !m_index->Jump(m_region, &m_hasAlignmentsInRegion) ) {
-        const string indexError = m_index->GetErrorString();
-        const string message = string("could not set region\n\t") + indexError;
+        const std::string indexError = m_index->GetErrorString();
+        const std::string message = std::string("could not set region\n\t") + indexError;
         SetErrorString("BamRandomAccessController::OpenIndex", message);
         return false;
     }

--- a/src/api/internal/bam/BamReader_p.cpp
+++ b/src/api/internal/bam/BamReader_p.cpp
@@ -25,7 +25,6 @@ using namespace BamTools::Internal;
 #include <iostream>
 #include <iterator>
 #include <vector>
-using namespace std;
 
 // constructor
 BamReaderPrivate::BamReaderPrivate(BamReader* parent)
@@ -58,8 +57,8 @@ bool BamReaderPrivate::Close(void) {
         try {
             m_stream.Close();
         } catch ( BamException& e ) {
-            const string streamError = e.what();
-            const string message = string("encountered error closing BAM file: \n\t") + streamError;
+            const std::string streamError = e.what();
+            const std::string message = std::string("encountered error closing BAM file: \n\t") + streamError;
             SetErrorString("BamReader::Close", message);
             return false;
         }
@@ -82,15 +81,15 @@ bool BamReaderPrivate::CreateIndex(const BamIndex::IndexType& type) {
     if ( m_randomAccessController.CreateIndex(this, type) )
         return true;
     else {
-        const string bracError = m_randomAccessController.GetErrorString();
-        const string message = string("could not create index: \n\t") + bracError;
+        const std::string bracError = m_randomAccessController.GetErrorString();
+        const std::string message = std::string("could not create index: \n\t") + bracError;
         SetErrorString("BamReader::CreateIndex", message);
         return false;
     }
 }
 
 // return path & filename of current BAM file
-const string BamReaderPrivate::Filename(void) const {
+const std::string BamReaderPrivate::Filename(void) const {
     return m_filename;
 }
 
@@ -98,12 +97,12 @@ const SamHeader& BamReaderPrivate::GetConstSamHeader(void) const {
     return m_header.ToConstSamHeader();
 }
 
-string BamReaderPrivate::GetErrorString(void) const {
+std::string BamReaderPrivate::GetErrorString(void) const {
     return m_errorString;
 }
 
-// return header data as std::string
-string BamReaderPrivate::GetHeaderText(void) const {
+// return header data as string
+std::string BamReaderPrivate::GetHeaderText(void) const {
     return m_header.ToString();
 }
 
@@ -125,8 +124,8 @@ bool BamReaderPrivate::GetNextAlignment(BamAlignment& alignment) {
         if ( alignment.BuildCharData() )
             return true;
         else {
-            const string alError = alignment.GetErrorString();
-            const string message = string("could not populate alignment data: \n\t") + alError;
+            const std::string alError = alignment.GetErrorString();
+            const std::string message = std::string("could not populate alignment data: \n\t") + alError;
             SetErrorString("BamReader::GetNextAlignment", message);
             return false;
         }
@@ -187,8 +186,8 @@ bool BamReaderPrivate::GetNextAlignmentCore(BamAlignment& alignment) {
         return true;
 
     } catch ( BamException& e ) {
-        const string streamError = e.what();
-        const string message = string("encountered error reading BAM alignment: \n\t") + streamError;
+        const std::string streamError = e.what();
+        const std::string message = std::string("encountered error reading BAM alignment: \n\t") + streamError;
         SetErrorString("BamReader::GetNextAlignmentCore", message);
         return false;
     }
@@ -203,10 +202,10 @@ const RefVector& BamReaderPrivate::GetReferenceData(void) const {
 }
 
 // returns RefID for given RefName (returns References.size() if not found)
-int BamReaderPrivate::GetReferenceID(const string& refName) const {
+int BamReaderPrivate::GetReferenceID(const std::string& refName) const {
 
     // retrieve names from reference data
-    vector<string> refNames;
+    std::vector<std::string> refNames;
     RefVector::const_iterator refIter = m_references.begin();
     RefVector::const_iterator refEnd  = m_references.end();
     for ( ; refIter != refEnd; ++refIter)
@@ -236,7 +235,7 @@ bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 
     // read in the 'block length' value, make sure it's not zero
     char buffer[sizeof(uint32_t)];
-    fill_n(buffer, sizeof(uint32_t), 0);
+    std::fill_n(buffer, sizeof(uint32_t), 0);
     m_stream.Read(buffer, sizeof(uint32_t));
     alignment.SupportData.BlockLength = BamTools::UnpackUnsignedInt(buffer);
     if ( m_isBigEndian ) BamTools::SwapEndian_32(alignment.SupportData.BlockLength);
@@ -341,7 +340,7 @@ bool BamReaderPrivate::LoadReferenceData(void) {
 
         // store data for reference
         RefData aReference;
-        aReference.RefName   = (string)((const char*)refName.Buffer);
+        aReference.RefName   = static_cast<std::string>((const char*)refName.Buffer);
         aReference.RefLength = refLength;
         m_references.push_back(aReference);
     }
@@ -355,15 +354,15 @@ bool BamReaderPrivate::LocateIndex(const BamIndex::IndexType& preferredType) {
     if ( m_randomAccessController.LocateIndex(this, preferredType) )
         return true;
     else {
-        const string bracError = m_randomAccessController.GetErrorString();
-        const string message = string("could not locate index: \n\t") + bracError;
+        const std::string bracError = m_randomAccessController.GetErrorString();
+        const std::string message = std::string("could not locate index: \n\t") + bracError;
         SetErrorString("BamReader::LocateIndex", message);
         return false;
     }
 }
 
 // opens BAM file (and index)
-bool BamReaderPrivate::Open(const string& filename) {
+bool BamReaderPrivate::Open(const std::string& filename) {
 
     try {
 
@@ -385,8 +384,8 @@ bool BamReaderPrivate::Open(const string& filename) {
         return true;
 
     } catch ( BamException& e ) {
-        const string error = e.what();
-        const string message = string("could not open file: ") + filename +
+        const std::string error = e.what();
+        const std::string message = std::string("could not open file: ") + filename +
                                "\n\t" + error;
         SetErrorString("BamReader::Open", message);
         return false;
@@ -398,8 +397,8 @@ bool BamReaderPrivate::OpenIndex(const std::string& indexFilename) {
     if ( m_randomAccessController.OpenIndex(indexFilename, this) )
         return true;
     else {
-        const string bracError = m_randomAccessController.GetErrorString();
-        const string message = string("could not open index: \n\t") + bracError;
+        const std::string bracError = m_randomAccessController.GetErrorString();
+        const std::string message = std::string("could not open index: \n\t") + bracError;
         SetErrorString("BamReader::OpenIndex", message);
         return false;
     }
@@ -415,8 +414,8 @@ bool BamReaderPrivate::Rewind(void) {
     if ( Seek(m_alignmentsBeginOffset) )
         return true;
     else {
-        const string currentError = m_errorString;
-        const string message = string("could not rewind: \n\t") + currentError;
+        const std::string currentError = m_errorString;
+        const std::string message = std::string("could not rewind: \n\t") + currentError;
         SetErrorString("BamReader::Rewind", message);
         return false;
     }
@@ -435,15 +434,15 @@ bool BamReaderPrivate::Seek(const int64_t& position) {
         return true;
     }
     catch ( BamException& e ) {
-        const string streamError = e.what();
-        const string message = string("could not seek in BAM file: \n\t") + streamError;
+        const std::string streamError = e.what();
+        const std::string message = std::string("could not seek in BAM file: \n\t") + streamError;
         SetErrorString("BamReader::Seek", message);
         return false;
     }
 }
 
-void BamReaderPrivate::SetErrorString(const string& where, const string& what) {
-    static const string SEPARATOR = ": ";
+void BamReaderPrivate::SetErrorString(const std::string& where, const std::string& what) {
+    static const std::string SEPARATOR(": ");
     m_errorString = where + SEPARATOR + what;
 }
 
@@ -458,8 +457,8 @@ bool BamReaderPrivate::SetRegion(const BamRegion& region) {
     if ( m_randomAccessController.SetRegion(region, m_references.size()) )
         return true;
     else {
-        const string bracError = m_randomAccessController.GetErrorString();
-        const string message = string("could not set region: \n\t") + bracError;
+        const std::string bracError = m_randomAccessController.GetErrorString();
+        const std::string message = std::string("could not set region: \n\t") + bracError;
         SetErrorString("BamReader::SetRegion", message);
         return false;
     }

--- a/src/api/internal/bam/BamWriter_p.cpp
+++ b/src/api/internal/bam/BamWriter_p.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 
 #include <cstdlib>
 #include <cstring>
-using namespace std;
 
 // ctor
 BamWriterPrivate::BamWriterPrivate(void)
@@ -55,7 +54,7 @@ void BamWriterPrivate::Close(void) {
 }
 
 // creates a cigar string from the supplied alignment
-void BamWriterPrivate::CreatePackedCigar(const vector<CigarOp>& cigarOperations, string& packedCigar) {
+void BamWriterPrivate::CreatePackedCigar(const std::vector<CigarOp>& cigarOperations, std::string& packedCigar) {
 
     // initialize
     const size_t numCigarOperations = cigarOperations.size();
@@ -65,8 +64,8 @@ void BamWriterPrivate::CreatePackedCigar(const vector<CigarOp>& cigarOperations,
     unsigned int* pPackedCigar = (unsigned int*)packedCigar.data();
 
     // iterate over cigar operations
-    vector<CigarOp>::const_iterator coIter = cigarOperations.begin();
-    vector<CigarOp>::const_iterator coEnd  = cigarOperations.end();
+    std::vector<CigarOp>::const_iterator coIter = cigarOperations.begin();
+    std::vector<CigarOp>::const_iterator coEnd  = cigarOperations.end();
     for ( ; coIter != coEnd; ++coIter ) {
 
         // store op in packedCigar
@@ -82,7 +81,7 @@ void BamWriterPrivate::CreatePackedCigar(const vector<CigarOp>& cigarOperations,
             case (Constants::BAM_CIGAR_SEQMATCH_CHAR) : cigarOp = Constants::BAM_CIGAR_SEQMATCH; break;
             case (Constants::BAM_CIGAR_MISMATCH_CHAR) : cigarOp = Constants::BAM_CIGAR_MISMATCH; break;
             default:
-                const string message = string("invalid CIGAR operation type") + coIter->Type;
+                const std::string message = std::string("invalid CIGAR operation type") + coIter->Type;
                 throw BamException("BamWriter::CreatePackedCigar", message);
         }
 
@@ -92,7 +91,7 @@ void BamWriterPrivate::CreatePackedCigar(const vector<CigarOp>& cigarOperations,
 }
 
 // encodes the supplied query sequence into 4-bit notation
-void BamWriterPrivate::EncodeQuerySequence(const string& query, string& encodedQuery) {
+void BamWriterPrivate::EncodeQuerySequence(const std::string& query, std::string& encodedQuery) {
 
     // prepare the encoded query string
     const size_t queryLength = query.size();
@@ -123,7 +122,7 @@ void BamWriterPrivate::EncodeQuerySequence(const string& query, string& encodedQ
             case (Constants::BAM_DNA_B)     : nucleotideCode = Constants::BAM_BASECODE_B;     break;
             case (Constants::BAM_DNA_N)     : nucleotideCode = Constants::BAM_BASECODE_N;     break;
             default:
-                const string message = string("invalid base: ") + *pQuery;
+                const std::string message = std::string("invalid base: ") + *pQuery;
                 throw BamException("BamWriter::EncodeQuerySequence", message);
         }
 
@@ -153,8 +152,8 @@ bool BamWriterPrivate::IsOpen(void) const {
 }
 
 // opens the alignment archive
-bool BamWriterPrivate::Open(const string& filename,
-                            const string& samHeaderText,
+bool BamWriterPrivate::Open(const std::string& filename,
+                            const std::string& samHeaderText,
                             const RefVector& referenceSequences)
 {
     try {
@@ -218,13 +217,13 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
     const uint32_t alignmentBin = CalculateMinimumBin(al.Position, al.GetEndPosition());
 
     // create our packed cigar string
-    string packedCigar;
+    std::string packedCigar;
     CreatePackedCigar(al.CigarData, packedCigar);
     const unsigned int packedCigarLength = packedCigar.size();
 
     // encode the query
     unsigned int encodedQueryLength = 0;
-    string encodedQuery;
+    std::string encodedQuery;
     if ( queryLength > 0 ) {
         EncodeQuerySequence(al.QueryBases, encodedQuery);
         encodedQueryLength = encodedQuery.size();
@@ -371,7 +370,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
                                 break;
                             default:
                                 delete[] tagData;
-                                const string message = string("invalid binary array type: ") + arrayType;
+                                const std::string message = std::string("invalid binary array type: ") + arrayType;
                                 throw BamException("BamWriter::SaveAlignment", message);
                         }
                     }
@@ -381,7 +380,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
 
                 default :
                     delete[] tagData;
-                    const string message = string("invalid tag type: ") + type;
+                    const std::string message = std::string("invalid tag type: ") + type;
                     throw BamException("BamWriter::SaveAlignment", message);
             }
         }

--- a/src/api/internal/index/BamIndexFactory_p.cpp
+++ b/src/api/internal/index/BamIndexFactory_p.cpp
@@ -12,27 +12,26 @@
 #include "api/internal/index/BamToolsIndex_p.h"
 using namespace BamTools;
 using namespace BamTools::Internal;
-using namespace std;
 
 // generates index filename from BAM filename (depending on requested type)
 // if type is unknown, returns empty string
-const string BamIndexFactory::CreateIndexFilename(const string& bamFilename,
+const std::string BamIndexFactory::CreateIndexFilename(const std::string& bamFilename,
                                                   const BamIndex::IndexType& type)
 {
     switch ( type ) {
         case ( BamIndex::STANDARD ) : return ( bamFilename + BamStandardIndex::Extension() );
         case ( BamIndex::BAMTOOLS ) : return ( bamFilename + BamToolsIndex::Extension() );
         default :
-            return string();
+            return std::string();
     }
 }
 
 // creates a new BamIndex object, depending on extension of @indexFilename
-BamIndex* BamIndexFactory::CreateIndexFromFilename(const string& indexFilename, BamReaderPrivate* reader) {
+BamIndex* BamIndexFactory::CreateIndexFromFilename(const std::string& indexFilename, BamReaderPrivate* reader) {
 
     // get file extension from index filename, including dot (".EXT")
     // if can't get file extension, return null index
-    const string extension = FileExtension(indexFilename);
+    const std::string extension = FileExtension(indexFilename);
     if ( extension.empty() )
         return 0;
 
@@ -56,18 +55,18 @@ BamIndex* BamIndexFactory::CreateIndexOfType(const BamIndex::IndexType& type,
 }
 
 // retrieves file extension (including '.')
-const string BamIndexFactory::FileExtension(const string& filename) {
+const std::string BamIndexFactory::FileExtension(const std::string& filename) {
 
     // if filename cannot contain valid path + extension, return empty string
     if ( filename.empty() || filename.length() <= 4 )
-        return string();
+        return std::string();
 
     // look for last dot in filename
     const size_t lastDotPosition = filename.find_last_of('.');
 
     // if none found, return empty string
-    if ( lastDotPosition == string::npos )
-        return string();
+    if ( lastDotPosition == std::string::npos )
+        return std::string();
 
     // return substring from last dot position
     return filename.substr(lastDotPosition);
@@ -76,16 +75,16 @@ const string BamIndexFactory::FileExtension(const string& filename) {
 // returns name of existing index file that corresponds to @bamFilename
 // will defer to @preferredType if possible, if not will attempt to load any supported type
 // returns empty string if not found
-const string BamIndexFactory::FindIndexFilename(const string& bamFilename,
+const std::string BamIndexFactory::FindIndexFilename(const std::string& bamFilename,
                                                 const BamIndex::IndexType& preferredType)
 {
     // skip if BAM filename provided is empty
     if ( bamFilename.empty() )
-        return string();
+        return std::string();
 
     // try to find index of preferred type first
     // return index filename if found
-    string indexFilename = CreateIndexFilename(bamFilename, preferredType);
+    std::string indexFilename = CreateIndexFilename(bamFilename, preferredType);
     if ( !indexFilename.empty() )
         return indexFilename;
 
@@ -103,5 +102,5 @@ const string BamIndexFactory::FindIndexFilename(const string& bamFilename,
     }
 
     // otherwise couldn't find any index matching this filename
-    return string();
+    return std::string();
 }

--- a/src/api/internal/index/BamToolsIndex_p.cpp
+++ b/src/api/internal/index/BamToolsIndex_p.cpp
@@ -23,14 +23,13 @@ using namespace BamTools::Internal;
 #include <iostream>
 #include <iterator>
 #include <map>
-using namespace std;
 
 // --------------------------------
 // static BamToolsIndex constants
 // --------------------------------
 
 const uint32_t BamToolsIndex::DEFAULT_BLOCK_LENGTH = 1000;
-const string BamToolsIndex::BTI_EXTENSION     = ".bti";
+const std::string BamToolsIndex::BTI_EXTENSION     = ".bti";
 const char* const BamToolsIndex::BTI_MAGIC    = "BTI\1";
 const int BamToolsIndex::SIZEOF_BLOCK         = sizeof(int32_t)*2 + sizeof(int64_t);
 
@@ -97,7 +96,7 @@ void BamToolsIndex::CheckVersion(void) {
 
     // if version is newer than can be supported by this version of bamtools
     else if ( m_inputVersion > m_outputVersion ) {
-        const string message = "unsupported format: this index was created by a newer version of BamTools. "
+        const std::string message = "unsupported format: this index was created by a newer version of BamTools. "
                                "Update your local version of BamTools to use the index file.";
         throw BamException("BamToolsIndex::CheckVersion", message);
     }
@@ -109,7 +108,7 @@ void BamToolsIndex::CheckVersion(void) {
     // Version 2.0: introduced support for half-open intervals, instead of the old closed intervals
     //   respondBy: throwing exception - we're not going to try to handle the old BTI files.
     else if ( (Version)m_inputVersion < BamToolsIndex::BTI_2_0 ) {
-        const string message = "unsupported format: this version of the index may not properly handle "
+        const std::string message = "unsupported format: this version of the index may not properly handle "
                                "coordinate intervals. Please run 'bamtools index -bti -in yourData.bam' "
                                "to generate an up-to-date, fixed BTI file.";
         throw BamException("BamToolsIndex::CheckVersion", message);
@@ -141,15 +140,15 @@ bool BamToolsIndex::Create(void) {
 
     // rewind BamReader
     if ( !m_reader->Rewind() ) {
-        const string readerError = m_reader->GetErrorString();
-        const string message = "could not create index: \n\t" + readerError;
+        const std::string readerError = m_reader->GetErrorString();
+        const std::string message = "could not create index: \n\t" + readerError;
         SetErrorString("BamToolsIndex::Create", message);
         return false;
     }
 
     try {
         // open new index file (read & write)
-        const string indexFilename = m_reader->Filename() + Extension();
+        const std::string indexFilename = m_reader->Filename() + Extension();
         OpenFile(indexFilename, IBamIODevice::ReadWrite);
 
         // initialize BtiFileSummary with number of references
@@ -264,8 +263,8 @@ bool BamToolsIndex::Create(void) {
 
     // rewind BamReader
     if ( !m_reader->Rewind() ) {
-        const string readerError = m_reader->GetErrorString();
-        const string message = "could not create index: \n\t" + readerError;
+        const std::string readerError = m_reader->GetErrorString();
+        const std::string message = "could not create index: \n\t" + readerError;
         SetErrorString("BamToolsIndex::Create", message);
         return false;
     }
@@ -295,8 +294,8 @@ void BamToolsIndex::GetOffset(const BamRegion& region, int64_t& offset, bool* ha
     BtiBlockConstIterator blockFirst = refEntry.Blocks.begin();
     BtiBlockConstIterator blockIter  = blockFirst;
     BtiBlockConstIterator blockLast  = refEntry.Blocks.end();
-    iterator_traits<BtiBlockConstIterator>::difference_type count = distance(blockFirst, blockLast);
-    iterator_traits<BtiBlockConstIterator>::difference_type step;
+    std::iterator_traits<BtiBlockConstIterator>::difference_type count = std::distance(blockFirst, blockLast);
+    std::iterator_traits<BtiBlockConstIterator>::difference_type step;
     while ( count > 0 ) {
         blockIter = blockFirst;
         step = count/2;
@@ -486,14 +485,14 @@ void BamToolsIndex::OpenFile(const std::string& filename, IBamIODevice::OpenMode
 
     m_resources.Device = BamDeviceFactory::CreateDevice(filename);
     if ( m_resources.Device == 0 ) {
-        const string message = string("could not open file: ") + filename;
+        const std::string message = std::string("could not open file: ") + filename;
         throw BamException("BamStandardIndex::OpenFile", message);
     }
 
     // attempt to open file
     m_resources.Device->Open(mode);
     if ( !IsDeviceOpen() ) {
-        const string message = string("could not open file: ") + filename;
+        const std::string message = std::string("could not open file: ") + filename;
         throw BamException("BamToolsIndex::OpenFile", message);
     }
 }

--- a/src/api/internal/io/BamDeviceFactory_p.cpp
+++ b/src/api/internal/io/BamDeviceFactory_p.cpp
@@ -16,9 +16,8 @@ using namespace BamTools;
 using namespace BamTools::Internal;
 
 #include <iostream>
-using namespace std;
 
-IBamIODevice* BamDeviceFactory::CreateDevice(const string& source) {
+IBamIODevice* BamDeviceFactory::CreateDevice(const std::string& source) {
 
     // check for requested pipe
     if ( source == "-" || source == "stdin" || source == "stdout" )

--- a/src/api/internal/io/BamFile_p.cpp
+++ b/src/api/internal/io/BamFile_p.cpp
@@ -13,9 +13,8 @@ using namespace BamTools::Internal;
 
 #include <cstdio>
 #include <iostream>
-using namespace std;
 
-BamFile::BamFile(const string& filename)
+BamFile::BamFile(const std::string& filename)
     : ILocalIODevice()
     , m_filename(filename)
 { }
@@ -52,8 +51,8 @@ bool BamFile::Open(const IBamIODevice::OpenMode mode) {
 
     // check that we obtained a valid FILE*
     if ( m_stream == 0 ) {
-        const string message_base = string("could not open file handle for ");
-        const string message = message_base + ( (m_filename.empty()) ? "empty filename" : m_filename );
+        const std::string message_base = std::string("could not open file handle for ");
+        const std::string message = message_base + ( (m_filename.empty()) ? "empty filename" : m_filename );
         SetErrorString("BamFile::Open", message);
         return false;
     }

--- a/src/api/internal/io/BamPipe_p.cpp
+++ b/src/api/internal/io/BamPipe_p.cpp
@@ -13,7 +13,6 @@ using namespace BamTools::Internal;
 
 #include <cstdio>
 #include <iostream>
-using namespace std;
 
 BamPipe::BamPipe(void) : ILocalIODevice() { }
 
@@ -42,17 +41,17 @@ bool BamPipe::Open(const IBamIODevice::OpenMode mode) {
 #endif // SYSTEM_NODEJS
 
     else {
-        const string errorType = string( (mode == IBamIODevice::ReadWrite) ? "unsupported"
+        const std::string errorType = std::string( (mode == IBamIODevice::ReadWrite) ? "unsupported"
                                                                            : "unknown" );
-        const string message = errorType + " open mode requested";
+        const std::string message = errorType + " open mode requested";
         SetErrorString("BamPipe::Open", message);
         return false;
     }
 
     // check that we obtained a valid FILE*
     if ( m_stream == 0 ) {
-        const string message_base = string("could not open handle on ");
-        const string message = message_base + ( (mode == IBamIODevice::ReadOnly) ? "stdin"
+        const std::string message_base = std::string("could not open handle on ");
+        const std::string message = message_base + ( (mode == IBamIODevice::ReadOnly) ? "stdin"
                                                                                  : "stdout" );
         SetErrorString("BamPipe::Open", message);
         return false;

--- a/src/api/internal/io/BgzfStream_p.cpp
+++ b/src/api/internal/io/BgzfStream_p.cpp
@@ -23,7 +23,6 @@ using namespace BamTools::Internal;
 #include <algorithm>
 #include <iostream>
 #include <sstream>
-using namespace std;
 
 // ---------------------------
 // BgzfStream implementation
@@ -210,13 +209,13 @@ void BgzfStream::FlushBlock(void) {
 
         // check for device error
         if ( numBytesWritten < 0 ) {
-            const string message = string("device error: ") + m_device->GetErrorString();
+            const std::string message = std::string("device error: ") + m_device->GetErrorString();
             throw BamException("BgzfStream::FlushBlock", message);
         }
 
         // check that we wrote expected numBytes
         if ( numBytesWritten != static_cast<int64_t>(blockLength) ) {
-            stringstream s("");
+            std::stringstream s;
             s << "expected to write " << blockLength
               << " bytes during flushing, but wrote " << numBytesWritten;
             throw BamException("BgzfStream::FlushBlock", s.str());
@@ -268,7 +267,7 @@ bool BgzfStream::IsOpen(void) const {
     return m_device->IsOpen();
 }
 
-void BgzfStream::Open(const string& filename, const IBamIODevice::OpenMode mode) {
+void BgzfStream::Open(const std::string& filename, const IBamIODevice::OpenMode mode) {
 
     // close current device if necessary
     Close();
@@ -280,8 +279,8 @@ void BgzfStream::Open(const string& filename, const IBamIODevice::OpenMode mode)
 
     // if device fails to open
     if ( !m_device->Open(mode) ) {
-        const string deviceError = m_device->GetErrorString();
-        const string message = string("could not open BGZF stream: \n\t") + deviceError;
+        const std::string deviceError = m_device->GetErrorString();
+        const std::string message = std::string("could not open BGZF stream: \n\t") + deviceError;
         throw BamException("BgzfStream::Open", message);
     }
 }
@@ -314,7 +313,7 @@ size_t BgzfStream::Read(char* data, const size_t dataLength) {
         }
 
         // copy data from uncompressed source buffer into data destination buffer
-        const size_t copyLength = min( (dataLength-numBytesRead), (size_t)bytesAvailable );
+        const size_t copyLength = std::min( (dataLength-numBytesRead), (size_t)bytesAvailable );
         memcpy(output, m_uncompressedBlock.Buffer + m_blockOffset, copyLength);
 
         // update counters
@@ -348,7 +347,7 @@ void BgzfStream::ReadBlock(void) {
 
     // check for device error
     if ( numBytesRead < 0 ) {
-        const string message = string("device error: ") + m_device->GetErrorString();
+        const std::string message = std::string("device error: ") + m_device->GetErrorString();
         throw BamException("BgzfStream::ReadBlock", message);
     }
 
@@ -376,7 +375,7 @@ void BgzfStream::ReadBlock(void) {
 
     // check for device error
     if ( numBytesRead < 0 ) {
-        const string message = string("device error: ") + m_device->GetErrorString();
+        const std::string message = std::string("device error: ") + m_device->GetErrorString();
         throw BamException("BgzfStream::ReadBlock", message);
     }
 
@@ -415,7 +414,7 @@ void BgzfStream::Seek(const int64_t& position) {
         m_blockOffset  = blockOffset;
     }
     else {
-        stringstream s("");
+        std::stringstream s;
         s << "unable to seek to position: " << position;
         throw BamException("BgzfStream::Seek", s.str());
     }
@@ -450,7 +449,7 @@ size_t BgzfStream::Write(const char* data, const size_t dataLength) {
     while ( numBytesWritten < dataLength ) {
 
         // copy data contents to uncompressed output buffer
-        unsigned int copyLength = min(blockLength - m_blockOffset, dataLength - numBytesWritten);
+        unsigned int copyLength = std::min(blockLength - m_blockOffset, dataLength - numBytesWritten);
         char* buffer = m_uncompressedBlock.Buffer;
         memcpy(buffer + m_blockOffset, input, copyLength);
 

--- a/src/api/internal/io/ByteArray_p.cpp
+++ b/src/api/internal/io/ByteArray_p.cpp
@@ -13,7 +13,6 @@ using namespace BamTools::Internal;
 
 #include <cstdlib>
 #include <cstring>
-using namespace std;
 
 // --------------------------
 // ByteArray implementation
@@ -23,16 +22,16 @@ ByteArray::ByteArray(void)
     : m_data()
 { }
 
-ByteArray::ByteArray(const string& value)
+ByteArray::ByteArray(const std::string& value)
     : m_data(value.begin(), value.end())
 { }
 
-ByteArray::ByteArray(const vector<char>& value)
+ByteArray::ByteArray(const std::vector<char>& value)
     : m_data(value)
 { }
 
 ByteArray::ByteArray(const char* value, size_t n) {
-    const string s(value, n);
+    const std::string s(value, n);
     m_data.assign(s.begin(), s.end());
 }
 
@@ -106,6 +105,6 @@ size_t ByteArray::Size(void) const {
 }
 
 void ByteArray::Squeeze(void) {
-    vector<char> t(m_data);
+    std::vector<char> t(m_data);
     t.swap(m_data);
 }

--- a/src/api/internal/io/HostAddress_p.cpp
+++ b/src/api/internal/io/HostAddress_p.cpp
@@ -15,7 +15,6 @@ using namespace BamTools::Internal;
 #include <cstdlib>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 // ------------------------
 // static utility methods
@@ -26,22 +25,22 @@ namespace Internal {
 
 // split a string into fields, on delimiter character
 static inline
-vector<string> Split(const string& source, char delim) {
-    stringstream ss(source);
-    string field;
-    vector<string> fields;
-    while ( getline(ss, field, delim) )
+std::vector<std::string> Split(const std::string& source, char delim) {
+    std::stringstream ss(source);
+    std::string field;
+    std::vector<std::string> fields;
+    while ( std::getline(ss, field, delim) )
         fields.push_back(field);
     return fields;
 }
 
 // return number of occurrences of @pattern in @source
 static inline
-uint8_t CountHits(const string& source, const string& pattern) {
+uint8_t CountHits(const std::string& source, const std::string& pattern) {
 
     uint8_t count(0);
     size_t found = source.find(pattern);
-    while ( found != string::npos ) {
+    while ( found != std::string::npos ) {
         ++count;
         found = source.find(pattern, found+1);
     }
@@ -49,10 +48,10 @@ uint8_t CountHits(const string& source, const string& pattern) {
 }
 
 static
-bool ParseIp4(const string& address, uint32_t& maybeIp4 ) {
+bool ParseIp4(const std::string& address, uint32_t& maybeIp4 ) {
 
     // split IP address into string fields
-    vector<string> addressFields = Split(address, '.');
+    std::vector<std::string> addressFields = Split(address, '.');
     if ( addressFields.size() != 4 )
         return false;
 
@@ -60,14 +59,14 @@ bool ParseIp4(const string& address, uint32_t& maybeIp4 ) {
     uint32_t ipv4(0);
     for ( uint8_t i = 0; i < 4; ++i ) {
 
-        const string& field = addressFields.at(i);
+        const std::string& field = addressFields.at(i);
         const size_t fieldSize = field.size();
         for ( size_t j = 0; j < fieldSize; ++j ) {
             if ( !isdigit(field[j]) )
                 return false;
         }
 
-        int value = atoi( addressFields.at(i).c_str() );
+        int value = std::atoi( addressFields.at(i).c_str() );
         if ( value < 0 || value > 255 )
             return false;
 
@@ -82,18 +81,18 @@ bool ParseIp4(const string& address, uint32_t& maybeIp4 ) {
 }
 
 static
-bool ParseIp6(const string& address, uint8_t* maybeIp6 ) {
+bool ParseIp6(const std::string& address, uint8_t* maybeIp6 ) {
 
-    string tmp = address;
+    std::string tmp = address;
 
     // look for '%' char (if found, lop off that part of address)
     // we're going to ignore any link-local zone index, for now at least
     const size_t percentFound = tmp.rfind('%');
-    if ( percentFound != string::npos )
+    if ( percentFound != std::string::npos )
         tmp = tmp.substr(0, percentFound);
 
     // split IP address into string fields
-    vector<string> fields = Split(tmp, ':');
+    std::vector<std::string> fields = Split(tmp, ':');
     const uint8_t numFields = fields.size();
     if ( numFields < 3 || numFields > 8 )
         return false;
@@ -106,7 +105,7 @@ bool ParseIp6(const string& address, uint8_t* maybeIp6 ) {
     // check valid IPv6 'compression'
     // must be valid 'pure' IPv6 or mixed IPv4/6 notation
     const size_t dotFound = tmp.find('.');
-    const bool isMixed = ( dotFound != string::npos );
+    const bool isMixed = ( dotFound != std::string::npos );
     if ( numColonColons != 1 && (numFields < (isMixed ? 7 : 8)) )
         return false;
 
@@ -116,14 +115,14 @@ bool ParseIp6(const string& address, uint8_t* maybeIp6 ) {
     for ( int8_t i = numFields - 1; i >= 0; --i ) {
         if ( index == 0 )
             return false;
-        const string& field = fields.at(i);
+        const std::string& field = fields.at(i);
 
         // if field empty
         if ( field.empty() ) {
 
             // if last field empty
             if ( i == numFields - 1 ) {
-                const string& previousField = fields.at(i-1);
+                const std::string& previousField = fields.at(i-1);
                 if ( previousField.empty() )
                     return false;
                 maybeIp6[--index] = 0;
@@ -133,7 +132,7 @@ bool ParseIp6(const string& address, uint8_t* maybeIp6 ) {
             // if first field empty
             else if ( i == 0 ) {
                 // make sure ':' isn't first character
-                const string& nextField = fields.at(i+1);
+                const std::string& nextField = fields.at(i+1);
                 if ( nextField.empty() ) return false;
                 maybeIp6[--index] = 0;
                 maybeIp6[--index] = 0;
@@ -308,7 +307,7 @@ IPv6Address HostAddress::GetIPv6Address(void) const {
 
 std::string HostAddress::GetIPString(void) const {
 
-    stringstream ss("");
+    std::stringstream ss;
 
     // IPv4 format
     if ( m_protocol == HostAddress::IPv4Protocol ) {
@@ -324,9 +323,9 @@ std::string HostAddress::GetIPString(void) const {
         for ( uint8_t i = 0; i < 8; ++i ) {
             if ( i != 0 )
                 ss << ':';
-            ss << hex << ( (uint16_t(m_ip6Address[2*i]) << 8) |
-                           (uint16_t(m_ip6Address[2*i+1]))
-                         );
+            ss << std::hex << ( (uint16_t(m_ip6Address[2*i]) << 8) |
+                                (uint16_t(m_ip6Address[2*i+1]))
+                              );
         }
     }
 
@@ -341,9 +340,9 @@ HostAddress::NetworkProtocol HostAddress::GetProtocol(void) const {
 bool HostAddress::ParseAddress(void) {
 
     // all IPv6 addresses should have a ':'
-    string s = m_ipString;
+    std::string s = m_ipString;
     size_t found = s.find(':');
-    if ( found != string::npos ) {
+    if ( found != std::string::npos ) {
         // try parse IP6 address
         uint8_t maybeIp6[16];
         if ( ParseIp6(s, maybeIp6) ) {
@@ -355,7 +354,7 @@ bool HostAddress::ParseAddress(void) {
 
     // all IPv4 addresses should have a '.'
     found = s.find('.');
-    if ( found != string::npos ) {
+    if ( found != std::string::npos ) {
         uint32_t maybeIp4(0);
         if ( ParseIp4(s, maybeIp4) ) {
             SetAddress(maybeIp4);

--- a/src/api/internal/io/HostInfo_p.cpp
+++ b/src/api/internal/io/HostInfo_p.cpp
@@ -22,7 +22,6 @@ using namespace BamTools::Internal;
 #include <cstdlib>
 #include <cstring>
 #include <set>
-using namespace std;
 
 // -------------------------
 // HostInfo implementation
@@ -41,7 +40,7 @@ HostInfo::HostInfo(const HostInfo& other)
 
 HostInfo::~HostInfo(void) { }
 
-vector<HostAddress> HostInfo::Addresses(void) const {
+std::vector<HostAddress> HostInfo::Addresses(void) const {
     return m_addresses;
 }
 
@@ -49,11 +48,11 @@ HostInfo::ErrorType HostInfo::GetError(void) const {
     return m_error;
 }
 
-string HostInfo::GetErrorString(void) const {
+std::string HostInfo::GetErrorString(void) const {
     return m_errorString;
 }
 
-string HostInfo::HostName(void) const {
+std::string HostInfo::HostName(void) const {
     return m_hostName;
 }
 
@@ -69,7 +68,7 @@ void HostInfo::SetErrorString(const std::string& errorString) {
     m_errorString = errorString;
 }
 
-void HostInfo::SetHostName(const string& name) {
+void HostInfo::SetHostName(const std::string& name) {
     m_hostName = name;
 }
 
@@ -78,11 +77,11 @@ void HostInfo::SetHostName(const string& name) {
 //  - the real "heavy-lifter" here
 // ---------------------------------
 
-HostInfo HostInfo::Lookup(const string& hostname, const string& port) {
+HostInfo HostInfo::Lookup(const std::string& hostname, const std::string& port) {
 
     HostInfo result;
     result.SetHostName(hostname);
-    set<HostAddress> uniqueAddresses;
+    std::set<HostAddress> uniqueAddresses;
 
 #ifdef _WIN32
     WindowsSockInit init;
@@ -102,7 +101,7 @@ HostInfo HostInfo::Lookup(const string& hostname, const string& port) {
     //       anyway. GetHostName() just won't quite show what I was hoping for. :(
     if ( address.HasIPAddress() ) {
 
-        const uint16_t portNum = static_cast<uint16_t>( atoi(port.c_str()) );
+        const uint16_t portNum = static_cast<uint16_t>( std::atoi(port.c_str()) );
 
         sockaddr_in  sa4;
         sockaddr_in6 sa6;
@@ -136,7 +135,7 @@ HostInfo HostInfo::Lookup(const string& hostname, const string& port) {
         char hbuf[NI_MAXHOST];
         char serv[NI_MAXSERV];
         if ( sa && (getnameinfo(sa, saSize, hbuf, sizeof(hbuf), serv, sizeof(serv), 0) == 0) )
-            result.SetHostName(string(hbuf));
+            result.SetHostName(std::string(hbuf));
 
         // if no domain name found, just use the original address's IP string
         if ( result.HostName().empty() )
@@ -219,6 +218,6 @@ HostInfo HostInfo::Lookup(const string& hostname, const string& port) {
     }
 
     // store fetched addresses (converting set -> vector) in result & return
-    result.SetAddresses( vector<HostAddress>(uniqueAddresses.begin(), uniqueAddresses.end()) );
+    result.SetAddresses( std::vector<HostAddress>(uniqueAddresses.begin(), uniqueAddresses.end()) );
     return result;
 }

--- a/src/api/internal/io/HttpHeader_p.cpp
+++ b/src/api/internal/io/HttpHeader_p.cpp
@@ -15,7 +15,6 @@ using namespace BamTools::Internal;
 #include <cstdlib>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 namespace BamTools {
 
@@ -31,9 +30,9 @@ static const char DOT_CHAR     = '.';
 static const char NEWLINE_CHAR = '\n';
 static const char SPACE_CHAR   = ' ';
 
-static const string FIELD_NEWLINE   = "\r\n";
-static const string FIELD_SEPARATOR = ": ";
-static const string HTTP_STRING     = "HTTP/";
+static const std::string FIELD_NEWLINE   = "\r\n";
+static const std::string FIELD_SEPARATOR = ": ";
+static const std::string HTTP_STRING     = "HTTP/";
 
 } // namespace Constants
 
@@ -50,16 +49,16 @@ bool IsSpace(const char c) {
 }
 
 // split on hitting single char delim
-static vector<string> Split(const string& source, const char delim) {
-    stringstream ss(source);
-    string field;
-    vector<string> fields;
-    while ( getline(ss, field, delim) )
+static std::vector<std::string> Split(const std::string& source, const char delim) {
+    std::stringstream ss(source);
+    std::string field;
+    std::vector<std::string> fields;
+    while ( std::getline(ss, field, delim) )
         fields.push_back(field);
     return fields;
 }
 
-static string Trim(const string& source) {
+static std::string Trim(const std::string& source) {
 
     // skip if empty string
     if ( source.empty() )
@@ -86,7 +85,7 @@ static string Trim(const string& source) {
     }
 
     // return result
-    return string(s + start, (end-start) + 1);
+    return std::string(s + start, (end-start) + 1);
 }
 
 } // namespace Internal
@@ -102,7 +101,7 @@ HttpHeader::HttpHeader(void)
     , m_minorVersion(1)
 { }
 
-HttpHeader::HttpHeader(const string& s)
+HttpHeader::HttpHeader(const std::string& s)
     : m_isValid(true)
     , m_majorVersion(1)
     , m_minorVersion(1)
@@ -112,7 +111,7 @@ HttpHeader::HttpHeader(const string& s)
 
 HttpHeader::~HttpHeader(void) { }
 
-bool HttpHeader::ContainsKey(const string& key) const {
+bool HttpHeader::ContainsKey(const std::string& key) const {
     return ( m_fields.find(key) != m_fields.end() );
 }
 
@@ -124,33 +123,33 @@ int HttpHeader::GetMinorVersion(void) const {
     return m_minorVersion;
 }
 
-string HttpHeader::GetValue(const string& key) {
+std::string HttpHeader::GetValue(const std::string& key) {
     if ( ContainsKey(key) )
         return m_fields[key];
-    else return string();
+    else return std::string();
 }
 
 bool HttpHeader::IsValid(void) const {
     return m_isValid;
 }
 
-void HttpHeader::Parse(const string& s) {
+void HttpHeader::Parse(const std::string& s) {
 
     // trim whitespace from input string
-    const string trimmed = Trim(s);
+    const std::string trimmed = Trim(s);
 
     // split into list of header lines
-    vector<string> rawFields = Split(trimmed, Constants::NEWLINE_CHAR);
+    std::vector<std::string> rawFields = Split(trimmed, Constants::NEWLINE_CHAR);
 
     // prep our 'cleaned' fields container
-    vector<string> cleanFields;
+    std::vector<std::string> cleanFields;
     cleanFields.reserve(rawFields.size());
 
     // remove any empty fields and clean any trailing windows-style carriage returns ('\r')
-    vector<string>::iterator rawFieldIter = rawFields.begin();
-    vector<string>::iterator rawFieldEnd  = rawFields.end();
+    std::vector<std::string>::iterator rawFieldIter = rawFields.begin();
+    std::vector<std::string>::iterator rawFieldEnd  = rawFields.end();
     for ( ; rawFieldIter != rawFieldEnd; ++rawFieldIter ) {
-        string& field = (*rawFieldIter);
+        std::string& field = (*rawFieldIter);
 
         // skip empty fields
         if ( field.empty() )
@@ -171,8 +170,8 @@ void HttpHeader::Parse(const string& s) {
 
     // parse header lines
     int lineNumber = 0;
-    vector<string>::const_iterator fieldIter = cleanFields.begin();
-    vector<string>::const_iterator fieldEnd  = cleanFields.end();
+    std::vector<std::string>::const_iterator fieldIter = cleanFields.begin();
+    std::vector<std::string>::const_iterator fieldEnd  = cleanFields.end();
     for ( ; fieldIter != fieldEnd; ++fieldIter, ++lineNumber ) {
         if ( !ParseLine( (*fieldIter), lineNumber ) ) {
             m_isValid = false;
@@ -181,25 +180,25 @@ void HttpHeader::Parse(const string& s) {
     }
 }
 
-bool HttpHeader::ParseLine(const string& line, int) {
+bool HttpHeader::ParseLine(const std::string& line, int) {
 
     // find colon position, return failure if not found
     const size_t colonFound = line.find(Constants::COLON_CHAR);
-    if ( colonFound == string::npos )
+    if ( colonFound == std::string::npos )
         return false;
 
     // store key/value (without leading/trailing whitespace) & return success
-    const string key   = Trim(line.substr(0, colonFound));
-    const string value = Trim(line.substr(colonFound+1));
+    const std::string key   = Trim(line.substr(0, colonFound));
+    const std::string value = Trim(line.substr(colonFound+1));
     m_fields[key] = value;
     return true;
 }
 
-void HttpHeader::RemoveField(const string& key) {
+void HttpHeader::RemoveField(const std::string& key) {
     m_fields.erase(key);
 }
 
-void HttpHeader::SetField(const string& key, const string& value) {
+void HttpHeader::SetField(const std::string& key, const std::string& value) {
     m_fields[key] = value;
 }
 
@@ -212,15 +211,15 @@ void HttpHeader::SetVersion(int major, int minor) {
     m_minorVersion = minor;
 }
 
-string HttpHeader::ToString(void) const {
-    string result("");
+std::string HttpHeader::ToString(void) const {
+    std::string result;
     if ( m_isValid ) {
-        map<string, string>::const_iterator fieldIter = m_fields.begin();
-        map<string, string>::const_iterator fieldEnd  = m_fields.end();
+        std::map<std::string, std::string>::const_iterator fieldIter = m_fields.begin();
+        std::map<std::string, std::string>::const_iterator fieldEnd  = m_fields.end();
         for ( ; fieldIter != fieldEnd; ++fieldIter ) {
-            const string& key   = (*fieldIter).first;
-            const string& value = (*fieldIter).second;
-            const string& line  = key   + Constants::FIELD_SEPARATOR +
+            const std::string& key   = (*fieldIter).first;
+            const std::string& value = (*fieldIter).second;
+            const std::string& line  = key   + Constants::FIELD_SEPARATOR +
                                   value + Constants::FIELD_NEWLINE;
             result += line;
         }
@@ -232,8 +231,8 @@ string HttpHeader::ToString(void) const {
 // HttpRequestHeader implementation
 // ----------------------------------
 
-HttpRequestHeader::HttpRequestHeader(const string& method,
-                                     const string& resource,
+HttpRequestHeader::HttpRequestHeader(const std::string& method,
+                                     const std::string& resource,
                                      int majorVersion,
                                      int minorVersion)
     : HttpHeader()
@@ -245,15 +244,15 @@ HttpRequestHeader::HttpRequestHeader(const string& method,
 
 HttpRequestHeader::~HttpRequestHeader(void) { }
 
-string HttpRequestHeader::GetMethod(void) const {
+std::string HttpRequestHeader::GetMethod(void) const {
     return m_method;
 }
 
-string HttpRequestHeader::GetResource(void) const {
+std::string HttpRequestHeader::GetResource(void) const {
     return m_resource;
 }
 
-bool HttpRequestHeader::ParseLine(const string& line, int lineNumber) {
+bool HttpRequestHeader::ParseLine(const std::string& line, int lineNumber) {
 
     // if not 'request line', just let base class parse
     if ( lineNumber != 0 )
@@ -267,22 +266,22 @@ bool HttpRequestHeader::ParseLine(const string& line, int lineNumber) {
     //    GET /path/to/resource HTTP/1.1
     //    ^  ^^                ^^
     const size_t foundMethod = line.find_first_not_of(Constants::SPACE_CHAR); // skip any leading whitespace
-    if ( foundMethod == string::npos ) return false;
+    if ( foundMethod == std::string::npos ) return false;
     const size_t foundFirstSpace = line.find(Constants::SPACE_CHAR, foundMethod+1);
-    if ( foundFirstSpace == string::npos ) return false;
+    if ( foundFirstSpace == std::string::npos ) return false;
     const size_t foundResource = line.find_first_not_of(Constants::SPACE_CHAR, foundFirstSpace+1);
-    if ( foundResource == string::npos ) return false;
+    if ( foundResource == std::string::npos ) return false;
     const size_t foundSecondSpace = line.find(Constants::SPACE_CHAR, foundResource+1);
-    if ( foundSecondSpace == string::npos ) return false;
+    if ( foundSecondSpace == std::string::npos ) return false;
     const size_t foundVersion= line.find_first_not_of(Constants::SPACE_CHAR, foundSecondSpace+1);
-    if ( foundVersion == string::npos ) return false;
+    if ( foundVersion == std::string::npos ) return false;
 
     // parse out method & resource
     m_method   = line.substr(foundMethod,   foundFirstSpace  - foundMethod);
     m_resource = line.substr(foundResource, foundSecondSpace - foundResource);
 
     // parse out version numbers
-    const string temp = line.substr(foundVersion);
+    const std::string temp = line.substr(foundVersion);
     if ( (temp.find(Constants::HTTP_STRING) != 0) || (temp.size() != 8) )
         return false;
     const int major = static_cast<int>(temp.at(5) - '0');
@@ -293,8 +292,8 @@ bool HttpRequestHeader::ParseLine(const string& line, int lineNumber) {
     return true;
 }
 
-string HttpRequestHeader::ToString(void) const {
-    stringstream request("");
+std::string HttpRequestHeader::ToString(void) const {
+    std::stringstream request;
     request << m_method   << Constants::SPACE_CHAR
             << m_resource << Constants::SPACE_CHAR
             << Constants::HTTP_STRING << GetMajorVersion() << Constants::DOT_CHAR << GetMinorVersion()
@@ -309,7 +308,7 @@ string HttpRequestHeader::ToString(void) const {
 // -----------------------------------
 
 HttpResponseHeader::HttpResponseHeader(const int statusCode,
-                                       const string& reason,
+                                       const std::string& reason,
                                        int majorVersion,
                                        int minorVersion)
 
@@ -320,7 +319,7 @@ HttpResponseHeader::HttpResponseHeader(const int statusCode,
     SetVersion(majorVersion, minorVersion);
 }
 
-HttpResponseHeader::HttpResponseHeader(const string& s)
+HttpResponseHeader::HttpResponseHeader(const std::string& s)
     : HttpHeader()
     , m_statusCode(0)
 {
@@ -329,7 +328,7 @@ HttpResponseHeader::HttpResponseHeader(const string& s)
 
 HttpResponseHeader::~HttpResponseHeader(void) { }
 
-string HttpResponseHeader::GetReason(void) const  {
+std::string HttpResponseHeader::GetReason(void) const  {
     return m_reason;
 }
 
@@ -337,7 +336,7 @@ int HttpResponseHeader::GetStatusCode(void) const {
     return m_statusCode;
 }
 
-bool HttpResponseHeader::ParseLine(const string& line, int lineNumber) {
+bool HttpResponseHeader::ParseLine(const std::string& line, int lineNumber) {
 
     // if not 'status line', just let base class
     if ( lineNumber != 0 )
@@ -352,18 +351,18 @@ bool HttpResponseHeader::ParseLine(const string& line, int lineNumber) {
     //    ^       ^^  ^^
 
     const size_t foundVersion = line.find_first_not_of(Constants::SPACE_CHAR); // skip any leading whitespace
-    if ( foundVersion == string::npos ) return false;
+    if ( foundVersion == std::string::npos ) return false;
     const size_t foundFirstSpace = line.find(Constants::SPACE_CHAR, foundVersion+1);
-    if ( foundFirstSpace == string::npos ) return false;
+    if ( foundFirstSpace == std::string::npos ) return false;
     const size_t foundStatusCode = line.find_first_not_of(Constants::SPACE_CHAR, foundFirstSpace+1);
-    if ( foundStatusCode == string::npos ) return false;
+    if ( foundStatusCode == std::string::npos ) return false;
     const size_t foundSecondSpace = line.find(Constants::SPACE_CHAR, foundStatusCode+1);
-    if ( foundSecondSpace == string::npos ) return false;
+    if ( foundSecondSpace == std::string::npos ) return false;
     const size_t foundReason= line.find_first_not_of(Constants::SPACE_CHAR, foundSecondSpace+1);
-    if ( foundReason == string::npos ) return false;
+    if ( foundReason == std::string::npos ) return false;
 
     // parse version numbers
-    string temp = line.substr(foundVersion, foundFirstSpace - foundVersion);
+    std::string temp = line.substr(foundVersion, foundFirstSpace - foundVersion);
     if ( (temp.find(Constants::HTTP_STRING) != 0) || (temp.size() != 8) )
         return false;
     const int major = static_cast<int>(temp.at(5) - '0');
@@ -373,7 +372,7 @@ bool HttpResponseHeader::ParseLine(const string& line, int lineNumber) {
     // parse status code
     temp = line.substr(foundStatusCode, foundSecondSpace - foundStatusCode);
     if ( temp.size() != 3 ) return false;
-    m_statusCode = atoi( temp.c_str() );
+    m_statusCode = std::atoi( temp.c_str() );
 
     // reason phrase should be everything else left
     m_reason = line.substr(foundReason);
@@ -382,8 +381,8 @@ bool HttpResponseHeader::ParseLine(const string& line, int lineNumber) {
     return true;
 }
 
-string HttpResponseHeader::ToString(void) const {
-    stringstream response("");
+std::string HttpResponseHeader::ToString(void) const {
+    std::stringstream response;
     response << Constants::HTTP_STRING << GetMajorVersion() << Constants::DOT_CHAR << GetMinorVersion()
              << Constants::SPACE_CHAR  << m_statusCode
              << Constants::SPACE_CHAR  << m_reason

--- a/src/api/internal/io/ILocalIODevice_p.cpp
+++ b/src/api/internal/io/ILocalIODevice_p.cpp
@@ -12,7 +12,6 @@ using namespace BamTools;
 using namespace BamTools::Internal;
 
 #include <cstdio>
-using namespace std;
 
 ILocalIODevice::ILocalIODevice(void)
     : IBamIODevice()

--- a/src/api/internal/io/RollingBuffer_p.cpp
+++ b/src/api/internal/io/RollingBuffer_p.cpp
@@ -19,7 +19,6 @@ using namespace BamTools::Internal;
 #include <cstring>
 #include <algorithm>
 #include <string>
-using namespace std;
 
 // ------------------------------
 // RollingBuffer implementation
@@ -49,7 +48,7 @@ size_t RollingBuffer::BlockSize(void) const {
 }
 
 bool RollingBuffer::CanReadLine(void) const {
-    return IndexOf('\n') != string::npos;
+    return IndexOf('\n') != std::string::npos;
 }
 
 void RollingBuffer::Chop(size_t n) {
@@ -169,7 +168,7 @@ size_t RollingBuffer::IndexOf(char c) const {
 
     // skip processing if empty buffer
     if ( IsEmpty() )
-        return string::npos;
+        return std::string::npos;
 
     size_t index(0);
 
@@ -194,7 +193,7 @@ size_t RollingBuffer::IndexOf(char c) const {
     }
 
     // no match found
-    return string::npos;
+    return std::string::npos;
 }
 
 bool RollingBuffer::IsEmpty(void) const {

--- a/src/api/internal/io/TcpSocketEngine_unix_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_unix_p.cpp
@@ -19,7 +19,6 @@ using namespace BamTools::Internal;
 #include <cerrno>
 #include <ctime>
 #include <iostream>
-using namespace std;
 
 // ------------------------
 // static utility methods

--- a/src/api/internal/io/TcpSocketEngine_win_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_win_p.cpp
@@ -15,7 +15,6 @@ using namespace BamTools::Internal;
 #include <cstring>
 #include <iostream>
 #include <sstream>
-using namespace std;
 
 // --------------------------------
 // TcpSocketEngine implementation
@@ -153,7 +152,7 @@ bool TcpSocketEngine::nativeCreateSocket(HostAddress::NetworkProtocol protocol) 
                 break;
             default:
                 m_socketError = TcpSocket::UnknownSocketError;
-                stringstream errStream("");
+                std::stringstream errStream;
                 errStream << "WSA ErrorCode: " << errorCode;
                 m_errorString = errStream.str();
                 break;

--- a/src/api/internal/io/TcpSocket_p.cpp
+++ b/src/api/internal/io/TcpSocket_p.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 #include <climits>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 // ------------------------------------
 // static utility methods & constants
@@ -88,7 +87,7 @@ bool TcpSocket::ConnectImpl(const HostInfo& hostInfo,
     m_readBuffer.Clear();
 
     // fetch candidate addresses for requested host
-    vector<HostAddress> addresses = hostInfo.Addresses();
+    std::vector<HostAddress> addresses = hostInfo.Addresses();
     if ( addresses.empty() ) {
         m_error = TcpSocket::HostNotFoundError;
         m_errorString = "no IP addresses found for host";
@@ -96,13 +95,13 @@ bool TcpSocket::ConnectImpl(const HostInfo& hostInfo,
     }
 
     // convert port string to integer
-    stringstream ss(port);
+    std::stringstream ss(port);
     uint16_t portNumber(0);
     ss >> portNumber;
 
     // iterate through adddresses
-    vector<HostAddress>::const_iterator addrIter = addresses.begin();
-    vector<HostAddress>::const_iterator addrEnd  = addresses.end();
+    std::vector<HostAddress>::const_iterator addrIter = addresses.begin();
+    std::vector<HostAddress>::const_iterator addrEnd  = addresses.end();
     for ( ; addrIter != addrEnd; ++addrIter) {
         const HostAddress& addr = (*addrIter);
 
@@ -134,18 +133,18 @@ bool TcpSocket::ConnectImpl(const HostInfo& hostInfo,
     return false;
 }
 
-bool TcpSocket::ConnectToHost(const string& hostName,
+bool TcpSocket::ConnectToHost(const std::string& hostName,
                               uint16_t port,
                               IBamIODevice::OpenMode mode)
 {
-    stringstream ss("");
+    std::stringstream ss;
     ss << port;
     return ConnectToHost(hostName, ss.str(), mode);
 
 }
 
-bool TcpSocket::ConnectToHost(const string& hostName,
-                              const string& port,
+bool TcpSocket::ConnectToHost(const std::string& hostName,
+                              const std::string& port,
                               IBamIODevice::OpenMode mode)
 {
     // create new address object with requested host name
@@ -157,7 +156,7 @@ bool TcpSocket::ConnectToHost(const string& hostName,
     // otherwise host name was 'plain-text' ("www.foo.bar")
     // we need to look up IP address(es)
     if ( hostAddress.HasIPAddress() )
-        info.SetAddresses( vector<HostAddress>(1, hostAddress) );
+        info.SetAddresses( std::vector<HostAddress>(1, hostAddress) );
     else
         info = HostInfo::Lookup(hostName, port);
 
@@ -311,7 +310,7 @@ int64_t TcpSocket::ReadFromSocket(void) {
     return numBytesRead;
 }
 
-string TcpSocket::ReadLine(int64_t max) {
+std::string TcpSocket::ReadLine(int64_t max) {
 
     // prep result byte buffer
     ByteArray result;
@@ -330,7 +329,7 @@ string TcpSocket::ReadLine(int64_t max) {
 
         int64_t readResult;
         do {
-            result.Resize( static_cast<size_t>(min(bufferMax, result.Size() + DEFAULT_BUFFER_SIZE)) );
+            result.Resize( static_cast<size_t>(std::min(bufferMax, result.Size() + DEFAULT_BUFFER_SIZE)) );
             readResult = ReadLine(result.Data()+readBytes, result.Size()-readBytes);
             if ( readResult > 0 || readBytes == 0 )
                 readBytes += readResult;
@@ -346,7 +345,7 @@ string TcpSocket::ReadLine(int64_t max) {
         result.Resize(static_cast<size_t>(readBytes));
 
     // return byte buffer as string
-    return string( result.ConstData(), result.Size() );
+    return std::string( result.ConstData(), result.Size() );
 }
 
 int64_t TcpSocket::ReadLine(char* dest, size_t max) {

--- a/src/api/internal/sam/SamFormatParser_p.cpp
+++ b/src/api/internal/sam/SamFormatParser_p.cpp
@@ -17,7 +17,6 @@ using namespace BamTools::Internal;
 #include <iostream>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 SamFormatParser::SamFormatParser(SamHeader& header)
     : m_header(header)
@@ -25,7 +24,7 @@ SamFormatParser::SamFormatParser(SamHeader& header)
 
 SamFormatParser::~SamFormatParser(void) { }
 
-void SamFormatParser::Parse(const string& headerText) {
+void SamFormatParser::Parse(const std::string& headerText) {
 
     // clear header's prior contents
     m_header.Clear();
@@ -35,20 +34,20 @@ void SamFormatParser::Parse(const string& headerText) {
         return;
 
     // other wise parse SAM lines
-    istringstream headerStream(headerText);
-    string headerLine("");
-    while ( getline(headerStream, headerLine) )
+    std::istringstream headerStream(headerText);
+    std::string headerLine;
+    while ( std::getline(headerStream, headerLine) )
          ParseSamLine(headerLine);
 }
 
-void SamFormatParser::ParseSamLine(const string& line) {
+void SamFormatParser::ParseSamLine(const std::string& line) {
 
     // skip if line is not long enough to contain true values
     if ( line.length() < 5 ) return;
 
     // determine token at beginning of line
-    const string firstToken = line.substr(0,3);
-    const string restOfLine = line.substr(4);
+    const std::string firstToken = line.substr(0,3);
+    const std::string restOfLine = line.substr(4);
     if      ( firstToken == Constants::SAM_HD_BEGIN_TOKEN) ParseHDLine(restOfLine);
     else if ( firstToken == Constants::SAM_SQ_BEGIN_TOKEN) ParseSQLine(restOfLine);
     else if ( firstToken == Constants::SAM_RG_BEGIN_TOKEN) ParseRGLine(restOfLine);
@@ -56,19 +55,19 @@ void SamFormatParser::ParseSamLine(const string& line) {
     else if ( firstToken == Constants::SAM_CO_BEGIN_TOKEN) ParseCOLine(restOfLine);
 }
 
-void SamFormatParser::ParseHDLine(const string& line) {
+void SamFormatParser::ParseHDLine(const std::string& line) {
 
     // split HD lines into tokens
-    vector<string> tokens = Split(line, Constants::SAM_TAB);
+    std::vector<std::string> tokens = Split(line, Constants::SAM_TAB);
 
     // iterate over tokens
-    vector<string>::const_iterator tokenIter = tokens.begin();
-    vector<string>::const_iterator tokenEnd  = tokens.end();
+    std::vector<std::string>::const_iterator tokenIter = tokens.begin();
+    std::vector<std::string>::const_iterator tokenEnd  = tokens.end();
     for ( ; tokenIter != tokenEnd; ++tokenIter ) {
 
         // get tag/value
-        const string tokenTag = (*tokenIter).substr(0,2);
-        const string tokenValue = (*tokenIter).substr(3);
+        const std::string tokenTag = (*tokenIter).substr(0,2);
+        const std::string tokenValue = (*tokenIter).substr(3);
 
         // set header contents
         if      ( tokenTag == Constants::SAM_HD_VERSION_TAG    ) m_header.Version    = tokenValue;
@@ -87,21 +86,21 @@ void SamFormatParser::ParseHDLine(const string& line) {
         throw BamException("SamFormatParser::ParseHDLine", "@HD line is missing VN tag");
 }
 
-void SamFormatParser::ParseSQLine(const string& line) {
+void SamFormatParser::ParseSQLine(const std::string& line) {
 
     SamSequence seq;
 
     // split SQ line into tokens
-    vector<string> tokens = Split(line, Constants::SAM_TAB);
+    std::vector<std::string> tokens = Split(line, Constants::SAM_TAB);
 
     // iterate over tokens
-    vector<string>::const_iterator tokenIter = tokens.begin();
-    vector<string>::const_iterator tokenEnd  = tokens.end();
+    std::vector<std::string>::const_iterator tokenIter = tokens.begin();
+    std::vector<std::string>::const_iterator tokenEnd  = tokens.end();
     for ( ; tokenIter != tokenEnd; ++tokenIter ) {
 
         // get tag/value
-        const string tokenTag = (*tokenIter).substr(0,2);
-        const string tokenValue = (*tokenIter).substr(3);
+        const std::string tokenTag = (*tokenIter).substr(0,2);
+        const std::string tokenValue = (*tokenIter).substr(3);
 
         // set sequence contents
         if      ( tokenTag == Constants::SAM_SQ_NAME_TAG       ) seq.Name = tokenValue;
@@ -128,21 +127,21 @@ void SamFormatParser::ParseSQLine(const string& line) {
     m_header.Sequences.Add(seq);
 }
 
-void SamFormatParser::ParseRGLine(const string& line) {
+void SamFormatParser::ParseRGLine(const std::string& line) {
 
     SamReadGroup rg;
 
     // split string into tokens
-    vector<string> tokens = Split(line, Constants::SAM_TAB);
+    std::vector<std::string> tokens = Split(line, Constants::SAM_TAB);
 
     // iterate over tokens
-    vector<string>::const_iterator tokenIter = tokens.begin();
-    vector<string>::const_iterator tokenEnd  = tokens.end();
+    std::vector<std::string>::const_iterator tokenIter = tokens.begin();
+    std::vector<std::string>::const_iterator tokenEnd  = tokens.end();
     for ( ; tokenIter != tokenEnd; ++tokenIter ) {
 
         // get token tag/value
-        const string tokenTag = (*tokenIter).substr(0,2);
-        const string tokenValue = (*tokenIter).substr(3);
+        const std::string tokenTag = (*tokenIter).substr(0,2);
+        const std::string tokenValue = (*tokenIter).substr(3);
 
         // set read group contents
         if      ( tokenTag == Constants::SAM_RG_ID_TAG                  ) rg.ID = tokenValue;
@@ -173,21 +172,21 @@ void SamFormatParser::ParseRGLine(const string& line) {
     m_header.ReadGroups.Add(rg);
 }
 
-void SamFormatParser::ParsePGLine(const string& line) {
+void SamFormatParser::ParsePGLine(const std::string& line) {
 
     SamProgram pg;
 
     // split string into tokens
-    vector<string> tokens = Split(line, Constants::SAM_TAB);
+    std::vector<std::string> tokens = Split(line, Constants::SAM_TAB);
 
     // iterate over tokens
-    vector<string>::const_iterator tokenIter = tokens.begin();
-    vector<string>::const_iterator tokenEnd  = tokens.end();
+    std::vector<std::string>::const_iterator tokenIter = tokens.begin();
+    std::vector<std::string>::const_iterator tokenEnd  = tokens.end();
     for ( ; tokenIter != tokenEnd; ++tokenIter ) {
 
         // get token tag/value
-        const string tokenTag = (*tokenIter).substr(0,2);
-        const string tokenValue = (*tokenIter).substr(3);
+        const std::string tokenTag = (*tokenIter).substr(0,2);
+        const std::string tokenValue = (*tokenIter).substr(3);
 
         // set program record contents
         if      ( tokenTag == Constants::SAM_PG_ID_TAG              ) pg.ID = tokenValue;
@@ -211,16 +210,16 @@ void SamFormatParser::ParsePGLine(const string& line) {
     m_header.Programs.Add(pg);
 }
 
-void SamFormatParser::ParseCOLine(const string& line) {
+void SamFormatParser::ParseCOLine(const std::string& line) {
     // simply add line to comments list
     m_header.Comments.push_back(line);
 }
 
-const vector<string> SamFormatParser::Split(const string& line, const char delim) {
-    vector<string> tokens;
-    stringstream lineStream(line);
-    string token;
-    while ( getline(lineStream, token, delim) )
+const std::vector<std::string> SamFormatParser::Split(const std::string& line, const char delim) {
+    std::vector<std::string> tokens;
+    std::stringstream lineStream(line);
+    std::string token;
+    while ( std::getline(lineStream, token, delim) )
         tokens.push_back(token);
     return tokens;
 }

--- a/src/api/internal/sam/SamFormatPrinter_p.cpp
+++ b/src/api/internal/sam/SamFormatPrinter_p.cpp
@@ -16,15 +16,14 @@ using namespace BamTools::Internal;
 #include <iostream>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 // ------------------------
 // static utility methods
 // ------------------------
 
 static inline
-const string FormatTag(const string& tag, const string& value) {
-    return string(Constants::SAM_TAB + tag + Constants::SAM_COLON + value);
+const std::string FormatTag(const std::string& tag, const std::string& value) {
+    return std::string(Constants::SAM_TAB + tag + Constants::SAM_COLON + value);
 }
 
 // ---------------------------------
@@ -37,10 +36,10 @@ SamFormatPrinter::SamFormatPrinter(const SamHeader& header)
 
 SamFormatPrinter::~SamFormatPrinter(void) { }
 
-const string SamFormatPrinter::ToString(void) const {
+const std::string SamFormatPrinter::ToString(void) const {
 
     // clear out stream
-    stringstream out("");
+    std::stringstream out;
 
     // generate formatted header text
     PrintHD(out);
@@ -78,7 +77,7 @@ void SamFormatPrinter::PrintHD(std::stringstream& out) const {
             }
         }
         // newline
-        out << endl;
+        out << std::endl;
     }
 }
 
@@ -120,7 +119,7 @@ void SamFormatPrinter::PrintSQ(std::stringstream& out) const {
         }
 
         // newline
-        out << endl;
+        out << std::endl;
     }
 }
 
@@ -189,7 +188,7 @@ void SamFormatPrinter::PrintRG(std::stringstream& out) const {
         }
 
         // newline
-        out << endl;
+        out << std::endl;
     }
 }
 
@@ -230,21 +229,21 @@ void SamFormatPrinter::PrintPG(std::stringstream& out) const {
         }
 
         // newline
-        out << endl;
+        out << std::endl;
     }
 }
 
 void SamFormatPrinter::PrintCO(std::stringstream& out) const {
 
     // iterate over comments
-    vector<string>::const_iterator commentIter = m_header.Comments.begin();
-    vector<string>::const_iterator commentEnd  = m_header.Comments.end();
+    std::vector<std::string>::const_iterator commentIter = m_header.Comments.begin();
+    std::vector<std::string>::const_iterator commentEnd  = m_header.Comments.end();
     for ( ; commentIter != commentEnd; ++commentIter ) {
 
         // @CO <Comment>
         out << Constants::SAM_CO_BEGIN_TOKEN
             << Constants::SAM_TAB
             << (*commentIter)
-            << endl;
+            << std::endl;
     }
 }

--- a/src/api/internal/sam/SamHeaderValidator_p.cpp
+++ b/src/api/internal/sam/SamHeaderValidator_p.cpp
@@ -17,14 +17,13 @@ using namespace BamTools::Internal;
 #include <cctype>
 #include <set>
 #include <sstream>
-using namespace std;
 
 // ------------------------
 // static utility methods
 // -------------------------
 
 static
-bool caseInsensitiveCompare(const string& lhs, const string& rhs) {
+bool caseInsensitiveCompare(const std::string& lhs, const std::string& rhs) {
 
     // can omit checking chars if lengths not equal
     const int lhsLength = lhs.length();
@@ -64,9 +63,9 @@ static const SamHeaderVersion SAM_VERSION_1_4 = SamHeaderVersion(1,4);
 //
 // ------------------------------------------------------------------------
 
-const string SamHeaderValidator::ERROR_PREFIX = "ERROR: ";
-const string SamHeaderValidator::WARN_PREFIX  = "WARNING: ";
-const string SamHeaderValidator::NEWLINE      = "\n";
+const std::string SamHeaderValidator::ERROR_PREFIX = "ERROR: ";
+const std::string SamHeaderValidator::WARN_PREFIX  = "WARNING: ";
+const std::string SamHeaderValidator::NEWLINE      = "\n";
 
 SamHeaderValidator::SamHeaderValidator(const SamHeader& header)
     : m_header(header)
@@ -74,47 +73,47 @@ SamHeaderValidator::SamHeaderValidator(const SamHeader& header)
 
 SamHeaderValidator::~SamHeaderValidator(void) { }
 
-void SamHeaderValidator::AddError(const string& message) {
+void SamHeaderValidator::AddError(const std::string& message) {
     m_errorMessages.push_back(ERROR_PREFIX + message + NEWLINE);
 }
 
-void SamHeaderValidator::AddWarning(const string& message) {
+void SamHeaderValidator::AddWarning(const std::string& message) {
     m_warningMessages.push_back(WARN_PREFIX + message + NEWLINE);
 }
 
-void SamHeaderValidator::PrintErrorMessages(ostream& stream) {
+void SamHeaderValidator::PrintErrorMessages(std::ostream& stream) {
 
     // skip if no error messages
     if ( m_errorMessages.empty() )
         return;
 
     // print error header line
-    stream << "* SAM header has " << m_errorMessages.size() << " errors:" << endl;
+    stream << "* SAM header has " << m_errorMessages.size() << " errors:" << std::endl;
 
     // print each error message
-    vector<string>::const_iterator errorIter = m_errorMessages.begin();
-    vector<string>::const_iterator errorEnd  = m_errorMessages.end();
+    std::vector<std::string>::const_iterator errorIter = m_errorMessages.begin();
+    std::vector<std::string>::const_iterator errorEnd  = m_errorMessages.end();
     for ( ; errorIter != errorEnd; ++errorIter )
         stream << (*errorIter);
 }
 
-void SamHeaderValidator::PrintMessages(ostream& stream) {
+void SamHeaderValidator::PrintMessages(std::ostream& stream) {
     PrintErrorMessages(stream);
     PrintWarningMessages(stream);
 }
 
-void SamHeaderValidator::PrintWarningMessages(ostream& stream) {
+void SamHeaderValidator::PrintWarningMessages(std::ostream& stream) {
 
     // skip if no warning messages
     if ( m_warningMessages.empty() )
         return;
 
     // print warning header line
-    stream << "* SAM header has " << m_warningMessages.size() << " warnings:" << endl;
+    stream << "* SAM header has " << m_warningMessages.size() << " warnings:" << std::endl;
 
     // print each warning message
-    vector<string>::const_iterator warnIter = m_warningMessages.begin();
-    vector<string>::const_iterator warnEnd  = m_warningMessages.end();
+    std::vector<std::string>::const_iterator warnIter = m_warningMessages.begin();
+    std::vector<std::string>::const_iterator warnEnd  = m_warningMessages.end();
     for ( ; warnIter != warnEnd; ++warnIter )
         stream << (*warnIter);
 }
@@ -141,7 +140,7 @@ bool SamHeaderValidator::ValidateMetadata(void) {
 // check SAM header version tag
 bool SamHeaderValidator::ValidateVersion(void) {
 
-    const string& version = m_header.Version;
+    const std::string& version = m_header.Version;
 
     // warn if version not present
     if ( version.empty() ) {
@@ -151,20 +150,20 @@ bool SamHeaderValidator::ValidateVersion(void) {
 
     // invalid if version does not contain a period
     const size_t periodFound = version.find(Constants::SAM_PERIOD);
-    if ( periodFound == string::npos ) {
+    if ( periodFound == std::string::npos ) {
         AddError("Invalid version (VN) format: " + version);
         return false;
     }
 
     // invalid if major version is empty or contains non-digits
-    const string majorVersion = version.substr(0, periodFound);
+    const std::string majorVersion = version.substr(0, periodFound);
     if ( majorVersion.empty() || !ContainsOnlyDigits(majorVersion) ) {
         AddError("Invalid version (VN) format: " + version);
         return false;
     }
 
     // invalid if major version is empty or contains non-digits
-    const string minorVersion = version.substr(periodFound + 1);
+    const std::string minorVersion = version.substr(periodFound + 1);
     if ( minorVersion.empty() || !ContainsOnlyDigits(minorVersion) ) {
         AddError("Invalid version (VN) format: " + version);
         return false;
@@ -178,15 +177,15 @@ bool SamHeaderValidator::ValidateVersion(void) {
 }
 
 // assumes non-empty input string
-bool SamHeaderValidator::ContainsOnlyDigits(const string& s) {
+bool SamHeaderValidator::ContainsOnlyDigits(const std::string& s) {
     const size_t nonDigitPosition = s.find_first_not_of(Constants::SAM_DIGITS);
-    return ( nonDigitPosition == string::npos ) ;
+    return ( nonDigitPosition == std::string::npos ) ;
 }
 
 // validate SAM header sort order tag
 bool SamHeaderValidator::ValidateSortOrder(void) {
 
-    const string& sortOrder = m_header.SortOrder;
+    const std::string& sortOrder = m_header.SortOrder;
 
     // warn if sort order not present
     if ( sortOrder.empty() ) {
@@ -211,7 +210,7 @@ bool SamHeaderValidator::ValidateSortOrder(void) {
 // validate SAM header group order tag
 bool SamHeaderValidator::ValidateGroupOrder(void) {
 
-    const string& groupOrder = m_header.GroupOrder;
+    const std::string& groupOrder = m_header.GroupOrder;
 
     // if no group order, no problem, just return OK
     if ( groupOrder.empty() )
@@ -256,8 +255,8 @@ bool SamHeaderValidator::ValidateSequenceDictionary(void) {
 bool SamHeaderValidator::ContainsUniqueSequenceNames(void) {
 
     bool isValid = true;
-    set<string> sequenceNames;
-    set<string>::iterator nameIter;
+    std::set<std::string> sequenceNames;
+    std::set<std::string>::iterator nameIter;
 
     // iterate over sequences
     const SamSequenceDictionary& sequences = m_header.Sequences;
@@ -267,7 +266,7 @@ bool SamHeaderValidator::ContainsUniqueSequenceNames(void) {
         const SamSequence& seq = (*seqIter);
 
         // lookup sequence name
-        const string& name = seq.Name;
+        const std::string& name = seq.Name;
         nameIter = sequenceNames.find(name);
 
         // error if found (duplicate entry)
@@ -293,7 +292,7 @@ bool SamHeaderValidator::ValidateSequence(const SamSequence& seq) {
 }
 
 // check sequence name is valid format
-bool SamHeaderValidator::CheckNameFormat(const string& name) {
+bool SamHeaderValidator::CheckNameFormat(const std::string& name) {
 
     // invalid if name is empty
     if ( name.empty() ) {
@@ -312,7 +311,7 @@ bool SamHeaderValidator::CheckNameFormat(const string& name) {
 }
 
 // check that sequence length is within accepted range
-bool SamHeaderValidator::CheckLengthInRange(const string& length) {
+bool SamHeaderValidator::CheckLengthInRange(const std::string& length) {
 
     // invalid if empty
     if ( length.empty() ) {
@@ -321,7 +320,7 @@ bool SamHeaderValidator::CheckLengthInRange(const string& length) {
     }
 
     // convert string length to numeric
-    stringstream lengthStream(length);
+    std::stringstream lengthStream(length);
     unsigned int sequenceLength;
     lengthStream >> sequenceLength;
 
@@ -360,10 +359,10 @@ bool SamHeaderValidator::ValidateReadGroupDictionary(void) {
 bool SamHeaderValidator::ContainsUniqueIDsAndPlatformUnits(void) {
 
     bool isValid = true;
-    set<string> readGroupIds;
-    set<string> platformUnits;
-    set<string>::iterator idIter;
-    set<string>::iterator puIter;
+    std::set<std::string> readGroupIds;
+    std::set<std::string> platformUnits;
+    std::set<std::string>::iterator idIter;
+    std::set<std::string>::iterator puIter;
 
     // iterate over sequences
     const SamReadGroupDictionary& readGroups = m_header.ReadGroups;
@@ -376,7 +375,7 @@ bool SamHeaderValidator::ContainsUniqueIDsAndPlatformUnits(void) {
         // check for unique ID
 
         // lookup read group ID
-        const string& id = rg.ID;
+        const std::string& id = rg.ID;
         idIter = readGroupIds.find(id);
 
         // error if found (duplicate entry)
@@ -392,7 +391,7 @@ bool SamHeaderValidator::ContainsUniqueIDsAndPlatformUnits(void) {
         // check for unique platform unit
 
         // lookup platform unit
-        const string& pu = rg.PlatformUnit;
+        const std::string& pu = rg.PlatformUnit;
         puIter = platformUnits.find(pu);
 
         // error if found (duplicate entry)
@@ -418,7 +417,7 @@ bool SamHeaderValidator::ValidateReadGroup(const SamReadGroup& rg) {
 }
 
 // make sure RG ID exists
-bool SamHeaderValidator::CheckReadGroupID(const string& id) {
+bool SamHeaderValidator::CheckReadGroupID(const std::string& id) {
 
     // invalid if empty
     if ( id.empty() ) {
@@ -431,7 +430,7 @@ bool SamHeaderValidator::CheckReadGroupID(const string& id) {
 }
 
 // make sure RG sequencing tech is one of the accepted keywords
-bool SamHeaderValidator::CheckSequencingTechnology(const string& technology) {
+bool SamHeaderValidator::CheckSequencingTechnology(const std::string& technology) {
 
     // if no technology provided, no problem, just return OK
     if ( technology.empty() )
@@ -467,8 +466,8 @@ bool SamHeaderValidator::ValidateProgramChain(void) {
 bool SamHeaderValidator::ContainsUniqueProgramIds(void) {
 
     bool isValid = true;
-    set<string> programIds;
-    set<string>::iterator pgIdIter;
+    std::set<std::string> programIds;
+    std::set<std::string>::iterator pgIdIter;
 
     // iterate over program records
     const SamProgramChain& programs = m_header.Programs;
@@ -478,7 +477,7 @@ bool SamHeaderValidator::ContainsUniqueProgramIds(void) {
         const SamProgram& pg = (*pgIter);
 
         // lookup program ID
-        const string& pgId = pg.ID;
+        const std::string& pgId = pg.ID;
         pgIdIter = programIds.find(pgId);
 
         // error if found (duplicate entry)
@@ -508,7 +507,7 @@ bool SamHeaderValidator::ValidatePreviousProgramIds(void) {
         const SamProgram& pg = (*pgIter);
 
         // ignore record for validation if PreviousProgramID is empty
-        const string& ppId = pg.PreviousProgramID;
+        const std::string& ppId = pg.PreviousProgramID;
         if ( ppId.empty() )
             continue;
 

--- a/src/api/internal/sam/SamHeaderVersion_p.h
+++ b/src/api/internal/sam/SamHeaderVersion_p.h
@@ -73,7 +73,7 @@ void SamHeaderVersion::SetVersion(const std::string& version) {
     // do nothing if version is empty
     if ( !version.empty() ) {
 
-        std::stringstream versionStream("");
+        std::stringstream versionStream;
 
         // do nothing if period not found
         const size_t periodFound = version.find(Constants::SAM_PERIOD);

--- a/src/api/internal/utils/BamException_p.cpp
+++ b/src/api/internal/utils/BamException_p.cpp
@@ -10,6 +10,5 @@
 #include "api/internal/utils/BamException_p.h"
 using namespace BamTools;
 using namespace BamTools::Internal;
-using namespace std;
 
-const string BamException::SEPARATOR = ": ";
+const std::string BamException::SEPARATOR(": ");

--- a/src/toolkit/bamtools.cpp
+++ b/src/toolkit/bamtools.cpp
@@ -27,30 +27,29 @@
 #include <sstream>
 #include <string>
 using namespace BamTools;
-using namespace std;
 
 // bamtools subtool names
-static const string CONVERT  = "convert";
-static const string COUNT    = "count";
-static const string COVERAGE = "coverage";
-static const string FILTER   = "filter";
-static const string HEADER   = "header";
-static const string INDEX    = "index";
-static const string MERGE    = "merge";
-static const string RANDOM   = "random";
-static const string RESOLVE  = "resolve";
-static const string REVERT   = "revert";
-static const string SORT     = "sort";
-static const string SPLIT    = "split";
-static const string STATS    = "stats";
+static const std::string CONVERT  = "convert";
+static const std::string COUNT    = "count";
+static const std::string COVERAGE = "coverage";
+static const std::string FILTER   = "filter";
+static const std::string HEADER   = "header";
+static const std::string INDEX    = "index";
+static const std::string MERGE    = "merge";
+static const std::string RANDOM   = "random";
+static const std::string RESOLVE  = "resolve";
+static const std::string REVERT   = "revert";
+static const std::string SORT     = "sort";
+static const std::string SPLIT    = "split";
+static const std::string STATS    = "stats";
 
 // bamtools help/version constants
-static const string HELP          = "help";
-static const string LONG_HELP     = "--help";
-static const string SHORT_HELP    = "-h";
-static const string VERSION       = "version";
-static const string LONG_VERSION  = "--version";
-static const string SHORT_VERSION = "-v";
+static const std::string HELP          = "help";
+static const std::string LONG_HELP     = "--help";
+static const std::string SHORT_HELP    = "-h";
+static const std::string VERSION       = "version";
+static const std::string LONG_VERSION  = "--version";
+static const std::string SHORT_VERSION = "-v";
 
 // determine if string is a help constant
 static bool IsHelp(char* str) {
@@ -67,7 +66,7 @@ static bool IsVersion(char* str) {
 }
 
 // subtool factory method
-AbstractTool* CreateTool(const string& arg) {
+AbstractTool* CreateTool(const std::string& arg) {
   
     // determine tool type based on arg
     if ( arg == CONVERT )  return new ConvertTool;
@@ -102,43 +101,43 @@ int Help(int argc, char* argv[]) {
     }
 
     // print general BamTools help message
-    cerr << endl;
-    cerr << "usage: bamtools [--help] COMMAND [ARGS]" << endl;
-    cerr << endl;
-    cerr << "Available bamtools commands:" << endl;
-    cerr << "\tconvert         Converts between BAM and a number of other formats" << endl;
-    cerr << "\tcount           Prints number of alignments in BAM file(s)" << endl;
-    cerr << "\tcoverage        Prints coverage statistics from the input BAM file" << endl;    
-    cerr << "\tfilter          Filters BAM file(s) by user-specified criteria" << endl;
-    cerr << "\theader          Prints BAM header information" << endl;
-    cerr << "\tindex           Generates index for BAM file" << endl;
-    cerr << "\tmerge           Merge multiple BAM files into single file" << endl;
-    cerr << "\trandom          Select random alignments from existing BAM file(s), intended more as a testing tool." << endl;
-    cerr << "\tresolve         Resolves paired-end reads (marking the IsProperPair flag as needed)" << endl;
-    cerr << "\trevert          Removes duplicate marks and restores original base qualities" << endl;
-    cerr << "\tsort            Sorts the BAM file according to some criteria" << endl;
-    cerr << "\tsplit           Splits a BAM file on user-specified property, creating a new BAM output file for each value found" << endl;
-    cerr << "\tstats           Prints some basic statistics from input BAM file(s)" << endl;
-    cerr << endl;
-    cerr << "See 'bamtools help COMMAND' for more information on a specific command." << endl;
-    cerr << endl;
+    std::cerr << std::endl;
+    std::cerr << "usage: bamtools [--help] COMMAND [ARGS]" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Available bamtools commands:" << std::endl;
+    std::cerr << "\tconvert         Converts between BAM and a number of other formats" << std::endl;
+    std::cerr << "\tcount           Prints number of alignments in BAM file(s)" << std::endl;
+    std::cerr << "\tcoverage        Prints coverage statistics from the input BAM file" << std::endl;    
+    std::cerr << "\tfilter          Filters BAM file(s) by user-specified criteria" << std::endl;
+    std::cerr << "\theader          Prints BAM header information" << std::endl;
+    std::cerr << "\tindex           Generates index for BAM file" << std::endl;
+    std::cerr << "\tmerge           Merge multiple BAM files into single file" << std::endl;
+    std::cerr << "\trandom          Select random alignments from existing BAM file(s), intended more as a testing tool." << std::endl;
+    std::cerr << "\tresolve         Resolves paired-end reads (marking the IsProperPair flag as needed)" << std::endl;
+    std::cerr << "\trevert          Removes duplicate marks and restores original base qualities" << std::endl;
+    std::cerr << "\tsort            Sorts the BAM file according to some criteria" << std::endl;
+    std::cerr << "\tsplit           Splits a BAM file on user-specified property, creating a new BAM output file for each value found" << std::endl;
+    std::cerr << "\tstats           Prints some basic statistics from input BAM file(s)" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "See 'bamtools help COMMAND' for more information on a specific command." << std::endl;
+    std::cerr << std::endl;
     return EXIT_SUCCESS;
 }
 
 // print version info
 int Version(void) {
 
-    stringstream versionStream("");
+    std::stringstream versionStream;
     versionStream << BAMTOOLS_VERSION_MAJOR << "."
                   << BAMTOOLS_VERSION_MINOR << "."
                   << BAMTOOLS_VERSION_BUILD;
 
-    cout << endl;
-    cout << "bamtools " << versionStream.str() << endl;
-    cout << "Part of BamTools API and toolkit" << endl;
-    cout << "Primary authors: Derek Barnett, Erik Garrison, Michael Stromberg" << endl;
-    cout << "(c) 2009-2012 Marth Lab, Biology Dept., Boston College" << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << "bamtools " << versionStream.str() << std::endl;
+    std::cout << "Part of BamTools API and toolkit" << std::endl;
+    std::cout << "Primary authors: Derek Barnett, Erik Garrison, Michael Stromberg" << std::endl;
+    std::cout << "(c) 2009-2012 Marth Lab, Biology Dept., Boston College" << std::endl;
+    std::cout << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/src/toolkit/bamtools_convert.cpp
+++ b/src/toolkit/bamtools_convert.cpp
@@ -22,7 +22,6 @@ using namespace BamTools;
 #include <sstream>
 #include <string>
 #include <vector>
-using namespace std;
   
 namespace BamTools { 
   
@@ -30,13 +29,13 @@ namespace BamTools {
 // ConvertTool constants
 
 // supported conversion format command-line names
-static const string FORMAT_BED    = "bed";
-static const string FORMAT_FASTA  = "fasta";
-static const string FORMAT_FASTQ  = "fastq";
-static const string FORMAT_JSON   = "json";
-static const string FORMAT_SAM    = "sam";
-static const string FORMAT_PILEUP = "pileup";
-static const string FORMAT_YAML   = "yaml";
+static const std::string FORMAT_BED    = "bed";
+static const std::string FORMAT_FASTA  = "fasta";
+static const std::string FORMAT_FASTQ  = "fastq";
+static const std::string FORMAT_JSON   = "json";
+static const std::string FORMAT_SAM    = "sam";
+static const std::string FORMAT_PILEUP = "pileup";
+static const std::string FORMAT_YAML   = "yaml";
 
 // other constants
 static const unsigned int FASTA_LINE_MAX = 50;
@@ -49,9 +48,9 @@ class ConvertPileupFormatVisitor : public PileupVisitor {
     // ctor & dtor
     public:
         ConvertPileupFormatVisitor(const RefVector& references,
-                                   const string& fastaFilename,
+                                   const std::string& fastaFilename,
                                    const bool isPrintingMapQualities,
-                                   ostream* out);
+                                   std::ostream* out);
         ~ConvertPileupFormatVisitor(void);
 
     // PileupVisitor interface implementation
@@ -63,7 +62,7 @@ class ConvertPileupFormatVisitor : public PileupVisitor {
         Fasta     m_fasta;
         bool      m_hasFasta;
         bool      m_isPrintingMapQualities;
-        ostream*  m_out;
+        std::ostream*  m_out;
         RefVector m_references;
 };
     
@@ -87,14 +86,14 @@ struct ConvertTool::ConvertSettings {
     bool IsPrintingPileupMapQualities;
     
     // options
-    vector<string> InputFiles;
-    string InputFilelist;
-    string OutputFilename;
-    string Format;
-    string Region;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
+    std::string OutputFilename;
+    std::string Format;
+    std::string Region;
     
     // pileup options
-    string FastaFilename;
+    std::string FastaFilename;
 
     // constructor
     ConvertSettings(void)
@@ -120,7 +119,7 @@ struct ConvertTool::ConvertToolPrivate {
     public:
         ConvertToolPrivate(ConvertTool::ConvertSettings* settings)
             : m_settings(settings)
-            , m_out(cout.rdbuf())
+            , m_out(std::cout.rdbuf())
         { }
 
         ~ConvertToolPrivate(void) { }
@@ -145,7 +144,7 @@ struct ConvertTool::ConvertToolPrivate {
     private: 
         ConvertTool::ConvertSettings* m_settings;
         RefVector m_references;
-        ostream m_out;
+        std::ostream m_out;
 };
 
 bool ConvertTool::ConvertToolPrivate::Run(void) {
@@ -160,28 +159,28 @@ bool ConvertTool::ConvertToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools convert ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools convert ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // open input files
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools convert ERROR: could not open input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools convert ERROR: could not open input BAM file(s)... Aborting." << std::endl;
         return false;
     }
 
     // if input is not stdin & a region is provided, look for index files
     if ( m_settings->HasInput && m_settings->HasRegion ) {
         if ( !reader.LocateIndexes() ) {
-            cerr << "bamtools convert ERROR: could not locate index file(s)... Aborting." << endl;
+            std::cerr << "bamtools convert ERROR: could not locate index file(s)... Aborting." << std::endl;
             return false;
         }
     }
@@ -196,30 +195,30 @@ bool ConvertTool::ConvertToolPrivate::Run(void) {
 
             if ( reader.HasIndexes() ) {
                 if ( !reader.SetRegion(region) ) {
-                    cerr << "bamtools convert ERROR: set region failed. Check that REGION describes a valid range" << endl;
+                    std::cerr << "bamtools convert ERROR: set region failed. Check that REGION describes a valid range" << std::endl;
                     reader.Close();
                     return false;
                 }
             }
 
         } else {
-            cerr << "bamtools convert ERROR: could not parse REGION: " << m_settings->Region << endl;
-            cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
-                 << endl;
+            std::cerr << "bamtools convert ERROR: could not parse REGION: " << m_settings->Region << std::endl;
+            std::cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
+                 << std::endl;
             reader.Close();
             return false;
         }
     }
         
     // if output file given
-    ofstream outFile;
+    std::ofstream outFile;
     if ( m_settings->HasOutput ) {
       
         // open output file stream
         outFile.open(m_settings->OutputFilename.c_str());
         if ( !outFile ) {
-            cerr << "bamtools convert ERROR: could not open " << m_settings->OutputFilename
-                 << " for output" << endl;
+            std::cerr << "bamtools convert ERROR: could not open " << m_settings->OutputFilename
+                 << " for output" << std::endl;
             return false; 
         }
         
@@ -251,8 +250,8 @@ bool ConvertTool::ConvertToolPrivate::Run(void) {
         else if ( m_settings->Format == FORMAT_SAM )   pFunction = &BamTools::ConvertTool::ConvertToolPrivate::PrintSam;
         else if ( m_settings->Format == FORMAT_YAML )  pFunction = &BamTools::ConvertTool::ConvertToolPrivate::PrintYaml;
         else { 
-            cerr << "bamtools convert ERROR: unrecognized format: " << m_settings->Format << endl;
-            cerr << "Please see documentation for list of supported formats " << endl;
+            std::cerr << "bamtools convert ERROR: unrecognized format: " << m_settings->Format << std::endl;
+            std::cerr << "Please see documentation for list of supported formats " << std::endl;
             formatError = true;
             convertedOk = false;
         }
@@ -297,7 +296,7 @@ void ConvertTool::ConvertToolPrivate::PrintBed(const BamAlignment& a) {
           << a.GetEndPosition() << "\t"
           << a.Name << "\t"
           << a.MapQuality << "\t"
-          << (a.IsReverseStrand() ? "-" : "+") << endl;
+          << (a.IsReverseStrand() ? "-" : "+") << std::endl;
 }
 
 // print BamAlignment in FASTA format
@@ -311,16 +310,16 @@ void ConvertTool::ConvertToolPrivate::PrintFasta(const BamAlignment& a) {
     // N.B. - QueryBases are reverse-complemented if aligned to reverse strand
   
     // print header
-    m_out << ">" << a.Name << endl;
+    m_out << ">" << a.Name << std::endl;
     
     // handle reverse strand alignment - bases 
-    string sequence = a.QueryBases;
+    std::string sequence = a.QueryBases;
     if ( a.IsReverseStrand() )
         Utilities::ReverseComplement(sequence);
     
     // if sequence fits on single line
     if ( sequence.length() <= FASTA_LINE_MAX )
-        m_out << sequence << endl;
+        m_out << sequence << std::endl;
     
     // else split over multiple lines
     else {
@@ -330,12 +329,12 @@ void ConvertTool::ConvertToolPrivate::PrintFasta(const BamAlignment& a) {
         
         // write subsequences to each line
         while ( position < (seqLength - FASTA_LINE_MAX) ) {
-            m_out << sequence.substr(position, FASTA_LINE_MAX) << endl;
+            m_out << sequence.substr(position, FASTA_LINE_MAX) << std::endl;
             position += FASTA_LINE_MAX;
         }
         
         // write final subsequence
-        m_out << sequence.substr(position) << endl;
+        m_out << sequence.substr(position) << std::endl;
     }
 }
 
@@ -352,23 +351,23 @@ void ConvertTool::ConvertToolPrivate::PrintFastq(const BamAlignment& a) {
     //        Name is appended "/1" or "/2" if paired-end, to reflect which mate this entry is.
   
     // handle paired-end alignments
-    string name = a.Name;
+    std::string name = a.Name;
     if ( a.IsPaired() )
         name.append( (a.IsFirstMate() ? "/1" : "/2") );
   
     // handle reverse strand alignment - bases & qualities
-    string qualities = a.Qualities;
-    string sequence  = a.QueryBases;
+    std::string qualities = a.Qualities;
+    std::string sequence  = a.QueryBases;
     if ( a.IsReverseStrand() ) {
         Utilities::Reverse(qualities);
         Utilities::ReverseComplement(sequence);
     }
   
     // write to output stream
-    m_out << "@" << name << endl
-          << sequence    << endl
-          << "+"         << endl
-          << qualities   << endl;
+    m_out << "@" << name << std::endl
+          << sequence    << std::endl
+          << "+"         << std::endl
+          << qualities   << std::endl;
 }
 
 // print BamAlignment in JSON format
@@ -385,12 +384,12 @@ void ConvertTool::ConvertToolPrivate::PrintJson(const BamAlignment& a) {
     m_out << "\"position\":" << a.Position+1 << ",\"mapQuality\":" << a.MapQuality << ",";
     
     // write CIGAR
-    const vector<CigarOp>& cigarData = a.CigarData;
+    const std::vector<CigarOp>& cigarData = a.CigarData;
     if ( !cigarData.empty() ) {
         m_out << "\"cigar\":[";
-        vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
-        vector<CigarOp>::const_iterator cigarIter  = cigarBegin;
-        vector<CigarOp>::const_iterator cigarEnd   = cigarData.end();
+        std::vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
+        std::vector<CigarOp>::const_iterator cigarIter  = cigarBegin;
+        std::vector<CigarOp>::const_iterator cigarEnd   = cigarData.end();
         for ( ; cigarIter != cigarEnd; ++cigarIter ) {
             const CigarOp& op = (*cigarIter);
             if (cigarIter != cigarBegin)
@@ -414,7 +413,7 @@ void ConvertTool::ConvertToolPrivate::PrintJson(const BamAlignment& a) {
     
     // write qualities
     if ( !a.Qualities.empty() && a.Qualities.at(0) != (char)0xFF ) {
-        string::const_iterator s = a.Qualities.begin();
+        std::string::const_iterator s = a.Qualities.begin();
         m_out << "\"qualities\":[" << static_cast<short>(*s) - 33;
         ++s;
         for ( ; s != a.Qualities.end(); ++s )
@@ -510,7 +509,7 @@ void ConvertTool::ConvertToolPrivate::PrintJson(const BamAlignment& a) {
         m_out << "}";
     }
 
-    m_out << "}" << endl;
+    m_out << "}" << std::endl;
 }
 
 // print BamAlignment in SAM format
@@ -532,11 +531,11 @@ void ConvertTool::ConvertToolPrivate::PrintSam(const BamAlignment& a) {
     m_out << a.Position+1 << "\t" << a.MapQuality << "\t";
     
     // write CIGAR
-    const vector<CigarOp>& cigarData = a.CigarData;
+    const std::vector<CigarOp>& cigarData = a.CigarData;
     if ( cigarData.empty() ) m_out << "*\t";
     else {
-        vector<CigarOp>::const_iterator cigarIter = cigarData.begin();
-        vector<CigarOp>::const_iterator cigarEnd  = cigarData.end();
+        std::vector<CigarOp>::const_iterator cigarIter = cigarData.begin();
+        std::vector<CigarOp>::const_iterator cigarEnd  = cigarData.end();
         for ( ; cigarIter != cigarEnd; ++cigarIter ) {
             const CigarOp& op = (*cigarIter);
             m_out << op.Length << op.Type;
@@ -575,7 +574,7 @@ void ConvertTool::ConvertToolPrivate::PrintSam(const BamAlignment& a) {
     while ( index < tagDataLength ) {
 
         // write tag name   
-        string tagName = a.TagData.substr(index, 2);
+        std::string tagName = a.TagData.substr(index, 2);
         m_out << "\t" << tagName << ":";
         index += 2;
         
@@ -640,45 +639,45 @@ void ConvertTool::ConvertToolPrivate::PrintSam(const BamAlignment& a) {
             break;
     }
 
-    m_out << endl;
+    m_out << std::endl;
 }
 
 // Print BamAlignment in YAML format
 void ConvertTool::ConvertToolPrivate::PrintYaml(const BamAlignment& a) {
 
     // write alignment name
-    m_out << "---" << endl;
-    m_out << a.Name << ":" << endl;
+    m_out << "---" << std::endl;
+    m_out << a.Name << ":" << std::endl;
 
     // write alignment data
-    m_out << "   " << "AlndBases: "     << a.AlignedBases << endl;
-    m_out << "   " << "Qualities: "     << a.Qualities << endl;
-    m_out << "   " << "Name: "          << a.Name << endl;
-    m_out << "   " << "Length: "        << a.Length << endl;
-    m_out << "   " << "TagData: "       << a.TagData << endl;
-    m_out << "   " << "RefID: "         << a.RefID << endl;
-    m_out << "   " << "RefName: "       << m_references[a.RefID].RefName << endl;
-    m_out << "   " << "Position: "      << a.Position << endl;
-    m_out << "   " << "Bin: "           << a.Bin << endl;
-    m_out << "   " << "MapQuality: "    << a.MapQuality << endl;
-    m_out << "   " << "AlignmentFlag: " << a.AlignmentFlag << endl;
-    m_out << "   " << "MateRefID: "     << a.MateRefID << endl;
-    m_out << "   " << "MatePosition: "  << a.MatePosition << endl;
-    m_out << "   " << "InsertSize: "    << a.InsertSize << endl;
-    m_out << "   " << "Filename: "      << a.Filename << endl;
+    m_out << "   " << "AlndBases: "     << a.AlignedBases << std::endl;
+    m_out << "   " << "Qualities: "     << a.Qualities << std::endl;
+    m_out << "   " << "Name: "          << a.Name << std::endl;
+    m_out << "   " << "Length: "        << a.Length << std::endl;
+    m_out << "   " << "TagData: "       << a.TagData << std::endl;
+    m_out << "   " << "RefID: "         << a.RefID << std::endl;
+    m_out << "   " << "RefName: "       << m_references[a.RefID].RefName << std::endl;
+    m_out << "   " << "Position: "      << a.Position << std::endl;
+    m_out << "   " << "Bin: "           << a.Bin << std::endl;
+    m_out << "   " << "MapQuality: "    << a.MapQuality << std::endl;
+    m_out << "   " << "AlignmentFlag: " << a.AlignmentFlag << std::endl;
+    m_out << "   " << "MateRefID: "     << a.MateRefID << std::endl;
+    m_out << "   " << "MatePosition: "  << a.MatePosition << std::endl;
+    m_out << "   " << "InsertSize: "    << a.InsertSize << std::endl;
+    m_out << "   " << "Filename: "      << a.Filename << std::endl;
 
     // write Cigar data
-    const vector<CigarOp>& cigarData = a.CigarData;
+    const std::vector<CigarOp>& cigarData = a.CigarData;
     if ( !cigarData.empty() ) {
         m_out << "   " <<  "Cigar: ";
-        vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
-        vector<CigarOp>::const_iterator cigarIter  = cigarBegin;
-        vector<CigarOp>::const_iterator cigarEnd   = cigarData.end();
+        std::vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
+        std::vector<CigarOp>::const_iterator cigarIter  = cigarBegin;
+        std::vector<CigarOp>::const_iterator cigarEnd   = cigarData.end();
         for ( ; cigarIter != cigarEnd; ++cigarIter ) {
             const CigarOp& op = (*cigarIter);
             m_out << op.Length << op.Type;
         }
-        m_out << endl;
+        m_out << std::endl;
     }
 }
 
@@ -772,9 +771,9 @@ int ConvertTool::Run(int argc, char* argv[]) {
 // ConvertPileupFormatVisitor implementation
 
 ConvertPileupFormatVisitor::ConvertPileupFormatVisitor(const RefVector& references, 
-                                                       const string& fastaFilename,
+                                                       const std::string& fastaFilename,
                                                        const bool isPrintingMapQualities,
-                                                       ostream* out)
+                                                       std::ostream* out)
     : PileupVisitor()
     , m_hasFasta(false)
     , m_isPrintingMapQualities(isPrintingMapQualities)
@@ -785,7 +784,7 @@ ConvertPileupFormatVisitor::ConvertPileupFormatVisitor(const RefVector& referenc
     if ( !fastaFilename.empty() ) {
       
         // check for FASTA index
-        string indexFilename = "";
+        std::string indexFilename;
         if ( Utilities::FileExists(fastaFilename + ".fai") ) 
             indexFilename = fastaFilename + ".fai";
       
@@ -809,14 +808,14 @@ void ConvertPileupFormatVisitor::Visit(const PileupPosition& pileupData ) {
     if ( pileupData.PileupAlignments.empty() ) return;
   
     // retrieve reference name
-    const string& referenceName = m_references[pileupData.RefId].RefName;
+    const std::string& referenceName = m_references[pileupData.RefId].RefName;
     const int& position   = pileupData.Position;
     
     // retrieve reference base from FASTA file, if one provided; otherwise default to 'N'
     char referenceBase('N');
     if ( m_hasFasta && (pileupData.Position < m_references[pileupData.RefId].RefLength) ) {
         if ( !m_fasta.GetBase(pileupData.RefId, pileupData.Position, referenceBase ) ) {
-            cerr << "bamtools convert ERROR: pileup conversion - could not read reference base from FASTA file" << endl;
+            std::cerr << "bamtools convert ERROR: pileup conversion - could not read reference base from FASTA file" << std::endl;
             return;
         }
     }
@@ -827,13 +826,13 @@ void ConvertPileupFormatVisitor::Visit(const PileupPosition& pileupData ) {
     // -----------------------------------------------------------
     // build strings based on alleles at this positionInAlignment
     
-    stringstream bases("");
-    stringstream baseQualities("");
-    stringstream mapQualities("");
+    std::stringstream bases;
+    std::stringstream baseQualities;
+    std::stringstream mapQualities;
     
     // iterate over alignments at this pileup position
-    vector<PileupAlignment>::const_iterator pileupIter = pileupData.PileupAlignments.begin();
-    vector<PileupAlignment>::const_iterator pileupEnd  = pileupData.PileupAlignments.end();
+    std::vector<PileupAlignment>::const_iterator pileupIter = pileupData.PileupAlignments.begin();
+    std::vector<PileupAlignment>::const_iterator pileupEnd  = pileupData.PileupAlignments.end();
     for ( ; pileupIter != pileupEnd; ++pileupIter ) {
         const PileupAlignment pa = (*pileupIter);
         const BamAlignment& ba = pa.Alignment;
@@ -878,7 +877,7 @@ void ConvertPileupFormatVisitor::Visit(const PileupPosition& pileupData ) {
                     char deletedBase('N');
                     if ( m_hasFasta && (pileupData.Position+i < m_references[pileupData.RefId].RefLength) ) {
                         if ( !m_fasta.GetBase(pileupData.RefId, pileupData.Position+i, deletedBase ) ) {
-                            cerr << "bamtools convert ERROR: pileup conversion - could not read reference base from FASTA file" << endl;
+                            std::cerr << "bamtools convert ERROR: pileup conversion - could not read reference base from FASTA file" << std::endl;
                             return;
                         }
                     }
@@ -908,12 +907,12 @@ void ConvertPileupFormatVisitor::Visit(const PileupPosition& pileupData ) {
     // tab-delimited
     // <refName> <1-based pos> <refBase> <numberAlleles> <bases> <qualities> [mapQuals]
     
-    const string TAB = "\t";
+    const std::string TAB = "\t";
     *m_out << referenceName       << TAB 
            << position + 1        << TAB 
            << referenceBase       << TAB 
            << numberAlleles       << TAB 
            << bases.str()         << TAB 
            << baseQualities.str() << TAB
-           << mapQualities.str()  << endl;
+           << mapQualities.str()  << std::endl;
 }

--- a/src/toolkit/bamtools_count.cpp
+++ b/src/toolkit/bamtools_count.cpp
@@ -19,7 +19,6 @@ using namespace BamTools;
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
 
 // ---------------------------------------------  
 // CountSettings implementation
@@ -32,9 +31,9 @@ struct CountTool::CountSettings {
     bool HasRegion;
 
     // filenames
-    vector<string> InputFiles;
-    string InputFilelist;
-    string Region;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
+    std::string Region;
     
     // constructor
     CountSettings(void)
@@ -75,21 +74,21 @@ bool CountTool::CountToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools count ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools count ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // open reader without index
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools count ERROR: could not open input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools count ERROR: could not open input BAM file(s)... Aborting." << std::endl;
         return false;
     }
 
@@ -118,7 +117,7 @@ bool CountTool::CountToolPrivate::Run(void) {
 
                 // attempt to set region on reader
                 if ( !reader.SetRegion(region.LeftRefID, region.LeftPosition, region.RightRefID, region.RightPosition) ) {
-                    cerr << "bamtools count ERROR: set region failed. Check that REGION describes a valid range" << endl;
+                    std::cerr << "bamtools count ERROR: set region failed. Check that REGION describes a valid range" << std::endl;
                     reader.Close();
                     return false;
                 }
@@ -143,16 +142,16 @@ bool CountTool::CountToolPrivate::Run(void) {
 
         // error parsing REGION string
         else {
-            cerr << "bamtools count ERROR: could not parse REGION - " << m_settings->Region << endl;
-            cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
-                 << endl;
+            std::cerr << "bamtools count ERROR: could not parse REGION - " << m_settings->Region << std::endl;
+            std::cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
+                 << std::endl;
             reader.Close();
             return false;
         }
     }
 
     // print results
-    cout << alignmentCount << endl;
+    std::cout << alignmentCount << std::endl;
 
     // clean up & exit
     reader.Close();

--- a/src/toolkit/bamtools_coverage.cpp
+++ b/src/toolkit/bamtools_coverage.cpp
@@ -18,7 +18,6 @@ using namespace BamTools;
 #include <fstream>
 #include <string>
 #include <vector>
-using namespace std;
   
 namespace BamTools {
  
@@ -28,7 +27,7 @@ namespace BamTools {
 class CoverageVisitor : public PileupVisitor {
   
     public:
-        CoverageVisitor(const RefVector& references, ostream* out)
+        CoverageVisitor(const RefVector& references, std::ostream* out)
             : PileupVisitor()
             , m_references(references)
             , m_out(out)
@@ -41,12 +40,12 @@ class CoverageVisitor : public PileupVisitor {
         void Visit(const PileupPosition& pileupData) {
             *m_out << m_references[pileupData.RefId].RefName << "\t" 
                    << pileupData.Position << "\t" 
-                   << pileupData.PileupAlignments.size() << endl;
+                   << pileupData.PileupAlignments.size() << std::endl;
         }
         
     private:
         RefVector m_references;
-        ostream*  m_out;
+        std::ostream*  m_out;
 };
 
 } // namespace BamTools
@@ -61,8 +60,8 @@ struct CoverageTool::CoverageSettings {
     bool HasOutputFile;
 
     // filenames
-    string InputBamFilename;
-    string OutputFilename;
+    std::string InputBamFilename;
+    std::string OutputFilename;
     
     // constructor
     CoverageSettings(void)
@@ -82,7 +81,7 @@ struct CoverageTool::CoverageToolPrivate {
     public:
         CoverageToolPrivate(CoverageTool::CoverageSettings* settings)
             : m_settings(settings)
-            , m_out(cout.rdbuf())
+            , m_out(std::cout.rdbuf())
         { }
 
         ~CoverageToolPrivate(void) { }
@@ -94,21 +93,21 @@ struct CoverageTool::CoverageToolPrivate {
     // data members
     private: 
         CoverageTool::CoverageSettings* m_settings;
-        ostream m_out;
+        std::ostream m_out;
         RefVector m_references;
 };  
 
 bool CoverageTool::CoverageToolPrivate::Run(void) {  
   
     // if output filename given
-    ofstream outFile;
+    std::ofstream outFile;
     if ( m_settings->HasOutputFile ) {
       
         // open output file stream
         outFile.open(m_settings->OutputFilename.c_str());
         if ( !outFile ) {
-            cerr << "bamtools coverage ERROR: could not open " << m_settings->OutputFilename
-                 << " for output" << endl;
+            std::cerr << "bamtools coverage ERROR: could not open " << m_settings->OutputFilename
+                 << " for output" << std::endl;
             return false; 
         }
         
@@ -119,7 +118,7 @@ bool CoverageTool::CoverageToolPrivate::Run(void) {
     //open our BAM reader
     BamReader reader;
     if ( !reader.Open(m_settings->InputBamFilename) ) {
-        cerr << "bamtools coverage ERROR: could not open input BAM file: " << m_settings->InputBamFilename << endl;
+        std::cerr << "bamtools coverage ERROR: could not open input BAM file: " << m_settings->InputBamFilename << std::endl;
         return false;
     }
 

--- a/src/toolkit/bamtools_filter.cpp
+++ b/src/toolkit/bamtools_filter.cpp
@@ -25,7 +25,6 @@ using namespace Json;
 #include <sstream>
 #include <string>
 #include <vector>
-using namespace std;
   
 namespace BamTools {
   
@@ -33,34 +32,34 @@ namespace BamTools {
 // string literal constants  
 
 // property names
-const string ALIGNMENTFLAG_PROPERTY       = "alignmentFlag";
-const string CIGAR_PROPERTY               = "cigar";
-const string INSERTSIZE_PROPERTY          = "insertSize";
-const string ISDUPLICATE_PROPERTY         = "isDuplicate";
-const string ISFAILEDQC_PROPERTY          = "isFailedQC";
-const string ISFIRSTMATE_PROPERTY         = "isFirstMate";
-const string ISMAPPED_PROPERTY            = "isMapped";
-const string ISMATEMAPPED_PROPERTY        = "isMateMapped";
-const string ISMATEREVERSESTRAND_PROPERTY = "isMateReverseStrand";
-const string ISPAIRED_PROPERTY            = "isPaired";
-const string ISPRIMARYALIGNMENT_PROPERTY  = "isPrimaryAlignment";
-const string ISPROPERPAIR_PROPERTY        = "isProperPair";
-const string ISREVERSESTRAND_PROPERTY     = "isReverseStrand";
-const string ISSECONDMATE_PROPERTY        = "isSecondMate";
-const string ISSINGLETON_PROPERTY         = "isSingleton";
-const string LENGTH_PROPERTY              = "length";
-const string MAPQUALITY_PROPERTY          = "mapQuality";
-const string MATEPOSITION_PROPERTY        = "matePosition";
-const string MATEREFERENCE_PROPERTY       = "mateReference";
-const string NAME_PROPERTY                = "name";
-const string POSITION_PROPERTY            = "position";
-const string QUERYBASES_PROPERTY          = "queryBases";
-const string REFERENCE_PROPERTY           = "reference";
-const string TAG_PROPERTY                 = "tag";
+const std::string ALIGNMENTFLAG_PROPERTY       = "alignmentFlag";
+const std::string CIGAR_PROPERTY               = "cigar";
+const std::string INSERTSIZE_PROPERTY          = "insertSize";
+const std::string ISDUPLICATE_PROPERTY         = "isDuplicate";
+const std::string ISFAILEDQC_PROPERTY          = "isFailedQC";
+const std::string ISFIRSTMATE_PROPERTY         = "isFirstMate";
+const std::string ISMAPPED_PROPERTY            = "isMapped";
+const std::string ISMATEMAPPED_PROPERTY        = "isMateMapped";
+const std::string ISMATEREVERSESTRAND_PROPERTY = "isMateReverseStrand";
+const std::string ISPAIRED_PROPERTY            = "isPaired";
+const std::string ISPRIMARYALIGNMENT_PROPERTY  = "isPrimaryAlignment";
+const std::string ISPROPERPAIR_PROPERTY        = "isProperPair";
+const std::string ISREVERSESTRAND_PROPERTY     = "isReverseStrand";
+const std::string ISSECONDMATE_PROPERTY        = "isSecondMate";
+const std::string ISSINGLETON_PROPERTY         = "isSingleton";
+const std::string LENGTH_PROPERTY              = "length";
+const std::string MAPQUALITY_PROPERTY          = "mapQuality";
+const std::string MATEPOSITION_PROPERTY        = "matePosition";
+const std::string MATEREFERENCE_PROPERTY       = "mateReference";
+const std::string NAME_PROPERTY                = "name";
+const std::string POSITION_PROPERTY            = "position";
+const std::string QUERYBASES_PROPERTY          = "queryBases";
+const std::string REFERENCE_PROPERTY           = "reference";
+const std::string TAG_PROPERTY                 = "tag";
 
 // boolalpha
-const string TRUE_STR  = "true";
-const string FALSE_STR = "false";
+const std::string TRUE_STR  = "true";
+const std::string FALSE_STR = "false";
     
 RefVector filterToolReferences;    
     
@@ -74,17 +73,17 @@ struct BamAlignmentChecker {
         for ( ; propertyIter != propertyEnd; ++propertyIter ) {
           
             // check alignment data field depending on propertyName
-            const string& propertyName = (*propertyIter).first;
+            const std::string& propertyName = (*propertyIter).first;
             const PropertyFilterValue& valueFilter = (*propertyIter).second;
             
             if      ( propertyName == ALIGNMENTFLAG_PROPERTY )  keepAlignment &= valueFilter.check(al.AlignmentFlag);
             else if ( propertyName == CIGAR_PROPERTY ) {
-                stringstream cigarSs;
-                const vector<CigarOp>& cigarData = al.CigarData;
+                std::stringstream cigarSs;
+                const std::vector<CigarOp>& cigarData = al.CigarData;
                 if ( !cigarData.empty() ) {
-                    vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
-                    vector<CigarOp>::const_iterator cigarIter = cigarBegin;
-                    vector<CigarOp>::const_iterator cigarEnd  = cigarData.end();
+                    std::vector<CigarOp>::const_iterator cigarBegin = cigarData.begin();
+                    std::vector<CigarOp>::const_iterator cigarIter = cigarBegin;
+                    std::vector<CigarOp>::const_iterator cigarEnd  = cigarData.end();
                     for ( ; cigarIter != cigarEnd; ++cigarIter ) {
                         const CigarOp& op = (*cigarIter);
                         cigarSs << op.Length << op.Type;
@@ -114,7 +113,7 @@ struct BamAlignmentChecker {
             else if ( propertyName == MATEREFERENCE_PROPERTY ) {
                 if ( !al.IsPaired() || !al.IsMateMapped() ) return false;
                 BAMTOOLS_ASSERT_MESSAGE( (al.MateRefID>=0 && (al.MateRefID<(int)filterToolReferences.size())), "Invalid MateRefID");
-                const string& refName = filterToolReferences.at(al.MateRefID).RefName;
+                const std::string& refName = filterToolReferences.at(al.MateRefID).RefName;
                 keepAlignment &= valueFilter.check(refName);
             }
             else if ( propertyName == NAME_PROPERTY )                 keepAlignment &= valueFilter.check(al.Name);
@@ -122,7 +121,7 @@ struct BamAlignmentChecker {
             else if ( propertyName == QUERYBASES_PROPERTY )           keepAlignment &= valueFilter.check(al.QueryBases);
             else if ( propertyName == REFERENCE_PROPERTY ) {
                 BAMTOOLS_ASSERT_MESSAGE( (al.RefID>=0 && (al.RefID<(int)filterToolReferences.size())), "Invalid RefID");
-                const string& refName = filterToolReferences.at(al.RefID).RefName;
+                const std::string& refName = filterToolReferences.at(al.RefID).RefName;
                 keepAlignment &= valueFilter.check(refName);
             }
             else if ( propertyName == TAG_PROPERTY ) keepAlignment &= checkAlignmentTag(valueFilter, al);
@@ -140,10 +139,10 @@ struct BamAlignmentChecker {
      
         // ensure filter contains string data
         Variant entireTagFilter = valueFilter.Value;
-        if ( !entireTagFilter.is_type<string>() ) return false;
+        if ( !entireTagFilter.is_type<std::string>() ) return false;
 
         // localize string from variant
-        const string& entireTagFilterString = entireTagFilter.get<string>();
+        const std::string& entireTagFilterString = entireTagFilter.get<std::string>();
 
         // ensure we have at least "XX:x"
         if ( entireTagFilterString.length() < 4 ) return false;
@@ -151,19 +150,19 @@ struct BamAlignmentChecker {
         // get tagName & lookup in alignment
         // if found, set tagType to tag type character
         // if not found, return false
-        const string& tagName = entireTagFilterString.substr(0,2);
+        const std::string& tagName = entireTagFilterString.substr(0,2);
         char tagType = '\0';
         if ( !al.GetTagType(tagName, tagType) ) return false;
 
         // remove tagName & ":" from beginning tagFilter
-        string tagFilterString = entireTagFilterString.substr(3);
+        std::string tagFilterString = entireTagFilterString.substr(3);
 
         // switch on tag type to set tag query value & parse filter token
         int8_t   asciiFilterValue,   asciiQueryValue;
         int32_t  intFilterValue,    intQueryValue;
         uint32_t uintFilterValue,   uintQueryValue;
         float    realFilterValue,   realQueryValue;
-        string   stringFilterValue, stringQueryValue;
+        std::string stringFilterValue, stringQueryValue;
 
         PropertyFilterValue tagFilter;
         PropertyFilterValue::ValueCompareType compareType;
@@ -259,11 +258,11 @@ struct FilterTool::FilterSettings {
     bool IsForceCompression;
 
     // filenames
-    vector<string> InputFiles;
-    string InputFilelist;
-    string OutputFilename;
-    string Region;
-    string ScriptFilename;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
+    std::string OutputFilename;
+    std::string Region;
+    std::string ScriptFilename;
 
     // -----------------------------------
     // General filter opts
@@ -278,13 +277,13 @@ struct FilterTool::FilterSettings {
     bool HasTagFilter; //(s)
 
     // filters
-    string AlignmentFlagFilter;
-    string InsertSizeFilter;
-    string LengthFilter;
-    string MapQualityFilter;
-    string NameFilter;
-    string QueryBasesFilter;
-    string TagFilter;  // support multiple ?
+    std::string AlignmentFlagFilter;
+    std::string InsertSizeFilter;
+    std::string LengthFilter;
+    std::string MapQualityFilter;
+    std::string NameFilter;
+    std::string QueryBasesFilter;
+    std::string TagFilter;  // support multiple ?
 
     // -----------------------------------
     // AlignmentFlag filter opts
@@ -304,18 +303,18 @@ struct FilterTool::FilterSettings {
     bool HasIsSingletonFilter;
 
     // filters
-    string IsDuplicateFilter;
-    string IsFailedQCFilter;
-    string IsFirstMateFilter;
-    string IsMappedFilter;
-    string IsMateMappedFilter;
-    string IsMateReverseStrandFilter;
-    string IsPairedFilter;
-    string IsPrimaryAlignmentFilter;
-    string IsProperPairFilter;
-    string IsReverseStrandFilter;
-    string IsSecondMateFilter;
-    string IsSingletonFilter;
+    std::string IsDuplicateFilter;
+    std::string IsFailedQCFilter;
+    std::string IsFirstMateFilter;
+    std::string IsMappedFilter;
+    std::string IsMateMappedFilter;
+    std::string IsMateReverseStrandFilter;
+    std::string IsPairedFilter;
+    std::string IsPrimaryAlignmentFilter;
+    std::string IsProperPairFilter;
+    std::string IsReverseStrandFilter;
+    std::string IsSecondMateFilter;
+    std::string IsSingletonFilter;
 
     // ---------------------------------
     // constructor
@@ -378,18 +377,18 @@ class FilterTool::FilterToolPrivate {
         
     // internal methods
     private:
-        bool AddPropertyTokensToFilter(const string& filterName, const map<string, string>& propertyTokens);
+        bool AddPropertyTokensToFilter(const std::string& filterName, const std::map<std::string, std::string>& propertyTokens);
         bool CheckAlignment(const BamAlignment& al);
-        const string GetScriptContents(void);
+        const std::string GetScriptContents(void);
         void InitProperties(void);
         bool ParseCommandLine(void);
-        bool ParseFilterObject(const string& filterName, const Json::Value& filterObject);
+        bool ParseFilterObject(const std::string& filterName, const Json::Value& filterObject);
         bool ParseScript(void);
         bool SetupFilters(void);
         
     // data members
     private:
-        vector<string> m_propertyNames;
+        std::vector<std::string> m_propertyNames;
         FilterTool::FilterSettings* m_settings;
         FilterEngine<BamAlignmentChecker> m_filterEngine;
 };
@@ -405,25 +404,25 @@ FilterTool::FilterToolPrivate::FilterToolPrivate(FilterTool::FilterSettings* set
 // destructor
 FilterTool::FilterToolPrivate::~FilterToolPrivate(void) { }
 
-bool FilterTool::FilterToolPrivate::AddPropertyTokensToFilter(const string& filterName,
-                                                              const map<string,
-                                                              string>& propertyTokens)
+bool FilterTool::FilterToolPrivate::AddPropertyTokensToFilter(const std::string& filterName,
+                                                              const std::map<std::string,
+                                                              std::string>& propertyTokens)
 {
     // dummy temp values for token parsing
     bool boolValue;
     int32_t int32Value;
     uint16_t uint16Value;
     uint32_t uint32Value;
-    string stringValue;
+    std::string stringValue;
     PropertyFilterValue::ValueCompareType type;
   
     // iterate over property token map
-    map<string, string>::const_iterator mapIter = propertyTokens.begin();
-    map<string, string>::const_iterator mapEnd  = propertyTokens.end();
+    std::map<std::string, std::string>::const_iterator mapIter = propertyTokens.begin();
+    std::map<std::string, std::string>::const_iterator mapEnd  = propertyTokens.end();
     for ( ; mapIter != mapEnd; ++mapIter ) {
       
-        const string& propertyName = (*mapIter).first;
-        const string& token        = (*mapIter).second;
+        const std::string& propertyName = (*mapIter).first;
+        const std::string& token        = (*mapIter).second;
         
         // ------------------------------
         // convert token to value & compare type 
@@ -493,7 +492,7 @@ bool FilterTool::FilterToolPrivate::AddPropertyTokensToFilter(const string& filt
       
         // else unknown property 
         else {
-            cerr << "bamtools filter ERROR: unknown property - " << propertyName << endl;
+            std::cerr << "bamtools filter ERROR: unknown property - " << propertyName << std::endl;
             return false;
         }
     }
@@ -504,19 +503,19 @@ bool FilterTool::FilterToolPrivate::CheckAlignment(const BamAlignment& al) {
     return m_filterEngine.check(al);
 }
 
-const string FilterTool::FilterToolPrivate::GetScriptContents(void) {
+const std::string FilterTool::FilterToolPrivate::GetScriptContents(void) {
   
     // open script for reading
     FILE* inFile = fopen(m_settings->ScriptFilename.c_str(), "rb");
     if ( !inFile ) {
-        cerr << "bamtools filter ERROR: could not open script: "
-             << m_settings->ScriptFilename << " for reading" << endl;
-        return string();
+        std::cerr << "bamtools filter ERROR: could not open script: "
+             << m_settings->ScriptFilename << " for reading" << std::endl;
+        return std::string();
     }
     
     // read in entire script contents  
     char buffer[1024];
-    ostringstream docStream("");
+    std::ostringstream docStream;
     while ( true ) {
         
         // peek ahead, make sure there is data available
@@ -527,8 +526,8 @@ const string FilterTool::FilterToolPrivate::GetScriptContents(void) {
         
         // read next block of data
         if ( fgets(buffer, 1024, inFile) == 0 ) {
-            cerr << "bamtools filter ERROR: could not read script contents" << endl;
-            return string();
+            std::cerr << "bamtools filter ERROR: could not read script contents" << std::endl;
+            return std::string();
         }
         
         docStream << buffer;
@@ -570,8 +569,8 @@ void FilterTool::FilterToolPrivate::InitProperties(void) {
     m_propertyNames.push_back(TAG_PROPERTY);
     
     // add vector contents to FilterEngine<BamAlignmentChecker>
-    vector<string>::const_iterator propertyNameIter = m_propertyNames.begin();
-    vector<string>::const_iterator propertyNameEnd  = m_propertyNames.end();
+    std::vector<std::string>::const_iterator propertyNameIter = m_propertyNames.begin();
+    std::vector<std::string>::const_iterator propertyNameEnd  = m_propertyNames.end();
     for ( ; propertyNameIter != propertyNameEnd; ++propertyNameIter )
         m_filterEngine.addProperty((*propertyNameIter));
 }
@@ -579,11 +578,11 @@ void FilterTool::FilterToolPrivate::InitProperties(void) {
 bool FilterTool::FilterToolPrivate::ParseCommandLine(void) {
   
     // add a rule set to filter engine
-    const string CMD = "COMMAND_LINE";
+    const std::string CMD = "COMMAND_LINE";
     m_filterEngine.addFilter(CMD);
 
     // map property names to command line args
-    map<string, string> propertyTokens;
+    std::map<std::string, std::string> propertyTokens;
     if ( m_settings->HasAlignmentFlagFilter )       propertyTokens.insert( make_pair(ALIGNMENTFLAG_PROPERTY,       m_settings->AlignmentFlagFilter) );
     if ( m_settings->HasInsertSizeFilter )          propertyTokens.insert( make_pair(INSERTSIZE_PROPERTY,          m_settings->InsertSizeFilter) );
     if ( m_settings->HasIsDuplicateFilter )         propertyTokens.insert( make_pair(ISDUPLICATE_PROPERTY,         m_settings->IsDuplicateFilter) );
@@ -608,20 +607,20 @@ bool FilterTool::FilterToolPrivate::ParseCommandLine(void) {
     return AddPropertyTokensToFilter(CMD, propertyTokens);
 }
 
-bool FilterTool::FilterToolPrivate::ParseFilterObject(const string& filterName, const Json::Value& filterObject) {
+bool FilterTool::FilterToolPrivate::ParseFilterObject(const std::string& filterName, const Json::Value& filterObject) {
   
     // filter object parsing variables
     Json::Value null(Json::nullValue);
     Json::Value propertyValue;
     
     // store results
-    map<string, string> propertyTokens;
+    std::map<std::string, std::string> propertyTokens;
     
     // iterate over known properties
-    vector<string>::const_iterator propertyNameIter = m_propertyNames.begin();
-    vector<string>::const_iterator propertyNameEnd  = m_propertyNames.end();
+    std::vector<std::string>::const_iterator propertyNameIter = m_propertyNames.begin();
+    std::vector<std::string>::const_iterator propertyNameEnd  = m_propertyNames.end();
     for ( ; propertyNameIter != propertyNameEnd; ++propertyNameIter ) {
-        const string& propertyName = (*propertyNameIter);
+        const std::string& propertyName = (*propertyNameIter);
         
         // if property defined in filter, add to token list
         propertyValue = filterObject.get(propertyName, null);
@@ -639,7 +638,7 @@ bool FilterTool::FilterToolPrivate::ParseFilterObject(const string& filterName, 
 bool FilterTool::FilterToolPrivate::ParseScript(void) {
   
     // read in script contents from file
-    const string document = GetScriptContents();
+    const std::string document = GetScriptContents();
     std::istringstream sin(document);
     
     // set up JsonCPP reader and attempt to parse script
@@ -649,7 +648,7 @@ bool FilterTool::FilterToolPrivate::ParseScript(void) {
     const bool ok = Json::parseFromStream(rbuilder, sin, &root, &errs);
     if (!ok) {
         // use built-in error reporting mechanism to alert user what was wrong with the script
-        cerr  << "bamtools filter ERROR: failed to parse script - see error message(s) below" << endl
+        std::cerr  << "bamtools filter ERROR: failed to parse script - see error message(s) below" << std::endl
               << errs;
         return false;     
     }
@@ -669,7 +668,7 @@ bool FilterTool::FilterToolPrivate::ParseScript(void) {
             Json::Value filter = (*filtersIter);
             
             // convert filter index to string
-            string filterName;
+            std::string filterName;
             
             // if id tag supplied
             const Json::Value id = filter["id"];
@@ -678,7 +677,7 @@ bool FilterTool::FilterToolPrivate::ParseScript(void) {
             
             // use array index 
             else {
-                stringstream convert;
+                std::stringstream convert;
                 convert << filterIndex;
                 filterName = convert.str();
             }
@@ -689,7 +688,7 @@ bool FilterTool::FilterToolPrivate::ParseScript(void) {
         
         // see if user defined a "rule" for these filters
         // otherwise, use filter engine's default rule behavior
-        string ruleString("");
+        std::string ruleString;
         const Json::Value rule = root["rule"];
         if ( rule.isString() )
             ruleString = rule.asString();
@@ -716,14 +715,14 @@ bool FilterTool::FilterToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools filter ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools filter ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
@@ -735,12 +734,12 @@ bool FilterTool::FilterToolPrivate::Run(void) {
     // open reader without index
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools filter ERROR: could not open input files for reading." << endl;
+        std::cerr << "bamtools filter ERROR: could not open input files for reading." << std::endl;
         return false;
     }
 
     // retrieve reader header & reference data
-    const string headerText = reader.GetHeaderText();
+    const std::string headerText = reader.GetHeaderText();
     filterToolReferences = reader.GetReferenceData();
     
     // determine compression mode for BamWriter
@@ -753,7 +752,7 @@ bool FilterTool::FilterToolPrivate::Run(void) {
     BamWriter writer;
     writer.SetCompressionMode(compressionMode);
     if ( !writer.Open(m_settings->OutputFilename, headerText, filterToolReferences) ) {
-        cerr << "bamtools filter ERROR: could not open " << m_settings->OutputFilename << " for writing." << endl;
+        std::cerr << "bamtools filter ERROR: could not open " << m_settings->OutputFilename << " for writing." << std::endl;
         reader.Close();
         return false;
     }
@@ -782,7 +781,7 @@ bool FilterTool::FilterToolPrivate::Run(void) {
 
                 // attempt to use SetRegion(), if failed report error
                 if ( !reader.SetRegion(region.LeftRefID, region.LeftPosition, region.RightRefID, region.RightPosition) ) {
-                    cerr << "bamtools filter ERROR: set region failed. Check that REGION describes a valid range" << endl;
+                    std::cerr << "bamtools filter ERROR: set region failed. Check that REGION describes a valid range" << std::endl;
                     reader.Close();
                     return false;
                 } 
@@ -809,9 +808,9 @@ bool FilterTool::FilterToolPrivate::Run(void) {
         
         // error parsing REGION string
         else {
-            cerr << "bamtools filter ERROR: could not parse REGION: " << m_settings->Region << endl;
-            cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
-                 << endl;
+            std::cerr << "bamtools filter ERROR: could not parse REGION: " << m_settings->Region << std::endl;
+            std::cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
+                 << std::endl;
             reader.Close();
             return false;
         }
@@ -847,7 +846,7 @@ FilterTool::FilterTool(void)
     // ----------------------------------
     // set program details
 
-    const string usage = "[-in <filename> -in <filename> ... | -list <filelist>] "
+    const std::string usage = "[-in <filename> -in <filename> ... | -list <filelist>] "
                          "[-out <filename> | [-forceCompression]] [-region <REGION>] "
                          "[ [-script <filename] | [filterOptions] ]";
 
@@ -858,12 +857,12 @@ FilterTool::FilterTool(void)
 
     OptionGroup* IO_Opts = Options::CreateOptionGroup("Input & Output");
 
-    const string inDesc     = "the input BAM file(s)";
-    const string listDesc   = "the input BAM file list, one line per file";
-    const string outDesc    = "the output BAM file";
-    const string regionDesc = "only read data from this genomic region (see documentation for more details)";
-    const string scriptDesc = "the filter script file (see documentation for more details)";
-    const string forceDesc  = "if results are sent to stdout (like when piping to another tool), "
+    const std::string inDesc     = "the input BAM file(s)";
+    const std::string listDesc   = "the input BAM file list, one line per file";
+    const std::string outDesc    = "the output BAM file";
+    const std::string regionDesc = "only read data from this genomic region (see documentation for more details)";
+    const std::string scriptDesc = "the filter script file (see documentation for more details)";
+    const std::string forceDesc  = "if results are sent to stdout (like when piping to another tool), "
                               "default behavior is to leave output uncompressed. Use this flag to "
                               "override and force compression";
 
@@ -879,13 +878,13 @@ FilterTool::FilterTool(void)
 
     OptionGroup* FilterOpts = Options::CreateOptionGroup("General Filters");
 
-    const string flagDesc    = "keep reads with this *exact* alignment flag (for more detailed queries, see below)";
-    const string insertDesc  = "keep reads with insert size that matches pattern";
-    const string lengthDesc  = "keep reads with length that matches pattern";
-    const string mapQualDesc = "keep reads with map quality that matches pattern";
-    const string nameDesc    = "keep reads with name that matches pattern";
-    const string queryDesc   = "keep reads with motif that matches pattern";
-    const string tagDesc     = "keep reads with this key=>value pair";
+    const std::string flagDesc    = "keep reads with this *exact* alignment flag (for more detailed queries, see below)";
+    const std::string insertDesc  = "keep reads with insert size that matches pattern";
+    const std::string lengthDesc  = "keep reads with length that matches pattern";
+    const std::string mapQualDesc = "keep reads with map quality that matches pattern";
+    const std::string nameDesc    = "keep reads with name that matches pattern";
+    const std::string queryDesc   = "keep reads with motif that matches pattern";
+    const std::string tagDesc     = "keep reads with this key=>value pair";
 
     Options::AddValueOption("-alignmentFlag", "int",       flagDesc,    "", m_settings->HasAlignmentFlagFilter, m_settings->AlignmentFlagFilter, FilterOpts);
     Options::AddValueOption("-insertSize",    "int",       insertDesc,  "", m_settings->HasInsertSizeFilter,    m_settings->InsertSizeFilter,    FilterOpts);
@@ -900,19 +899,19 @@ FilterTool::FilterTool(void)
 
     OptionGroup* AlignmentFlagOpts = Options::CreateOptionGroup("Alignment Flag Filters");
 
-    const string boolArg           = "true/false";
-    const string isDupDesc         = "keep only alignments that are marked as duplicate?";
-    const string isFailQcDesc      = "keep only alignments that failed QC?";
-    const string isFirstMateDesc   = "keep only alignments marked as first mate?";
-    const string isMappedDesc      = "keep only alignments that were mapped?";
-    const string isMateMappedDesc  = "keep only alignments with mates that mapped";
-    const string isMateReverseDesc = "keep only alignments with mate on reverese strand?";
-    const string isPairedDesc      = "keep only alignments that were sequenced as paired?";
-    const string isPrimaryDesc     = "keep only alignments marked as primary?";
-    const string isProperPairDesc  = "keep only alignments that passed PE resolution?";
-    const string isReverseDesc     = "keep only alignments on reverse strand?";
-    const string isSecondMateDesc  = "keep only alignments marked as second mate?";
-    const string isSingletonDesc   = "keep only singletons";
+    const std::string boolArg           = "true/false";
+    const std::string isDupDesc         = "keep only alignments that are marked as duplicate?";
+    const std::string isFailQcDesc      = "keep only alignments that failed QC?";
+    const std::string isFirstMateDesc   = "keep only alignments marked as first mate?";
+    const std::string isMappedDesc      = "keep only alignments that were mapped?";
+    const std::string isMateMappedDesc  = "keep only alignments with mates that mapped";
+    const std::string isMateReverseDesc = "keep only alignments with mate on reverese strand?";
+    const std::string isPairedDesc      = "keep only alignments that were sequenced as paired?";
+    const std::string isPrimaryDesc     = "keep only alignments marked as primary?";
+    const std::string isProperPairDesc  = "keep only alignments that passed PE resolution?";
+    const std::string isReverseDesc     = "keep only alignments on reverse strand?";
+    const std::string isSecondMateDesc  = "keep only alignments marked as second mate?";
+    const std::string isSingletonDesc   = "keep only singletons";
 
     Options::AddValueOption("-isDuplicate",         boolArg, isDupDesc,         "", m_settings->HasIsDuplicateFilter,         m_settings->IsDuplicateFilter,         AlignmentFlagOpts, TRUE_STR);
     Options::AddValueOption("-isFailedQC",          boolArg, isFailQcDesc,      "", m_settings->HasIsFailedQCFilter,          m_settings->IsFailedQCFilter,          AlignmentFlagOpts, TRUE_STR);

--- a/src/toolkit/bamtools_header.cpp
+++ b/src/toolkit/bamtools_header.cpp
@@ -18,7 +18,6 @@ using namespace BamTools;
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
   
 // ---------------------------------------------
 // HeaderSettings implementation
@@ -30,8 +29,8 @@ struct HeaderTool::HeaderSettings {
     bool HasInputFilelist;
 
     // filenames
-    vector<string> InputFiles;
-    string InputFilelist;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
     
     // constructor
     HeaderSettings(void)
@@ -68,26 +67,26 @@ bool HeaderTool::HeaderToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools header ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools header ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // attemp to open BAM files
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools header ERROR: could not open BAM file(s) for reading... Aborting." << endl;
+        std::cerr << "bamtools header ERROR: could not open BAM file(s) for reading... Aborting." << std::endl;
         return false;
     }
 
     // dump (merged) header contents to stdout
-    cout << reader.GetHeaderText() << endl;
+    std::cout << reader.GetHeaderText() << std::endl;
 
     // clean up & exit
     reader.Close();

--- a/src/toolkit/bamtools_index.cpp
+++ b/src/toolkit/bamtools_index.cpp
@@ -15,7 +15,6 @@ using namespace BamTools;
 
 #include <iostream>
 #include <string>
-using namespace std;
 
 // ---------------------------------------------
 // IndexSettings implementation
@@ -27,7 +26,7 @@ struct IndexTool::IndexSettings {
     bool IsUsingBamtoolsIndex;
 
     // filenames
-    string InputBamFilename;
+    std::string InputBamFilename;
     
     // constructor
     IndexSettings(void)
@@ -64,8 +63,8 @@ bool IndexTool::IndexToolPrivate::Run(void) {
     // open our BAM reader
     BamReader reader;
     if ( !reader.Open(m_settings->InputBamFilename) ) {
-        cerr << "bamtools index ERROR: could not open BAM file: "
-             << m_settings->InputBamFilename << endl;
+        std::cerr << "bamtools index ERROR: could not open BAM file: "
+             << m_settings->InputBamFilename << std::endl;
         return false;
     }
 

--- a/src/toolkit/bamtools_merge.cpp
+++ b/src/toolkit/bamtools_merge.cpp
@@ -19,7 +19,6 @@ using namespace BamTools;
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
 
 // ---------------------------------------------
 // MergeSettings implementation
@@ -34,12 +33,12 @@ struct MergeTool::MergeSettings {
     bool HasRegion;
     
     // filenames
-    vector<string> InputFiles;
-    string InputFilelist;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
     
     // other parameters
-    string OutputFilename;
-    string Region;
+    std::string OutputFilename;
+    std::string Region;
     
     // constructor
     MergeSettings(void)
@@ -83,21 +82,21 @@ bool MergeTool::MergeToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools merge ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools merge ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // opens the BAM files (by default without checking for indexes)
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools merge ERROR: could not open input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools merge ERROR: could not open input BAM file(s)... Aborting." << std::endl;
         return false;
     }
 
@@ -115,8 +114,8 @@ bool MergeTool::MergeToolPrivate::Run(void) {
     BamWriter writer;
     writer.SetCompressionMode(compressionMode);
     if ( !writer.Open(m_settings->OutputFilename, mergedHeader, references) ) {
-        cerr << "bamtools merge ERROR: could not open "
-             << m_settings->OutputFilename << " for writing." << endl;
+        std::cerr << "bamtools merge ERROR: could not open "
+             << m_settings->OutputFilename << " for writing." << std::endl;
         reader.Close();
         return false;
     }
@@ -147,8 +146,8 @@ bool MergeTool::MergeToolPrivate::Run(void) {
                                        region.RightRefID,
                                        region.RightPosition) )
                 {
-                    cerr << "bamtools merge ERROR: set region failed. Check that REGION describes a valid range"
-                         << endl;
+                    std::cerr << "bamtools merge ERROR: set region failed. Check that REGION describes a valid range"
+                         << std::endl;
                     reader.Close();
                     return false;
                 }
@@ -175,9 +174,9 @@ bool MergeTool::MergeToolPrivate::Run(void) {
 
         // error parsing REGION string
         else {
-            cerr << "bamtools merge ERROR: could not parse REGION - " << m_settings->Region << endl;
-            cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
-                 << endl;
+            std::cerr << "bamtools merge ERROR: could not parse REGION - " << m_settings->Region << std::endl;
+            std::cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
+                 << std::endl;
             reader.Close();
             writer.Close();
             return false;

--- a/src/toolkit/bamtools_random.cpp
+++ b/src/toolkit/bamtools_random.cpp
@@ -21,7 +21,6 @@ using namespace BamTools;
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
   
 namespace BamTools {
   
@@ -52,11 +51,11 @@ struct RandomTool::RandomSettings {
 
     // parameters
     unsigned int AlignmentCount;
-    vector<string> InputFiles;
-    string InputFilelist;
-    string OutputFilename;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
+    std::string OutputFilename;
     unsigned int RandomNumberSeed;
-    string Region;
+    std::string Region;
     
     // constructor
     RandomSettings(void)
@@ -104,21 +103,21 @@ bool RandomTool::RandomToolPrivate::Run(void) {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools random ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools random ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // open our reader
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools random ERROR: could not open input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools random ERROR: could not open input BAM file(s)... Aborting." << std::endl;
         return false;
     }
 
@@ -127,16 +126,16 @@ bool RandomTool::RandomToolPrivate::Run(void) {
 
     // make sure index data is available
     if ( !reader.HasIndexes() ) {
-        cerr << "bamtools random ERROR: could not load index data for all input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools random ERROR: could not load index data for all input BAM file(s)... Aborting." << std::endl;
         reader.Close();
         return false;
     }
 
     // get BamReader metadata
-    const string headerText = reader.GetHeaderText();
+    const std::string headerText = reader.GetHeaderText();
     const RefVector references = reader.GetReferenceData();
     if ( references.empty() ) {
-        cerr << "bamtools random ERROR: no reference data available... Aborting." << endl;
+        std::cerr << "bamtools random ERROR: no reference data available... Aborting." << std::endl;
         reader.Close();
         return false;
     }
@@ -151,8 +150,8 @@ bool RandomTool::RandomToolPrivate::Run(void) {
     BamWriter writer;
     writer.SetCompressionMode(compressionMode);
     if ( !writer.Open(m_settings->OutputFilename, headerText, references) ) {
-        cerr << "bamtools random ERROR: could not open " << m_settings->OutputFilename
-             << " for writing... Aborting." << endl;
+        std::cerr << "bamtools random ERROR: could not open " << m_settings->OutputFilename
+             << " for writing... Aborting." << std::endl;
         reader.Close();
         return false;
     }
@@ -160,9 +159,9 @@ bool RandomTool::RandomToolPrivate::Run(void) {
     // if user specified a REGION constraint, attempt to parse REGION string
     BamRegion region;
     if ( m_settings->HasRegion && !Utilities::ParseRegionString(m_settings->Region, reader, region) ) {
-        cerr << "bamtools random ERROR: could not parse REGION: " << m_settings->Region << endl;
-        cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
-             << endl;
+        std::cerr << "bamtools random ERROR: could not parse REGION: " << m_settings->Region << std::endl;
+        std::cerr << "Check that REGION is in valid format (see documentation) and that the coordinates are valid"
+             << std::endl;
         reader.Close();
         writer.Close();
         return false;

--- a/src/toolkit/bamtools_resolve.cpp
+++ b/src/toolkit/bamtools_resolve.cpp
@@ -27,14 +27,13 @@ using namespace BamTools;
 #include <string>
 #include <utility>
 #include <vector>
-using namespace std;
 
 // --------------------------------------------------------------------------
 // general ResolveTool constants
 // --------------------------------------------------------------------------
 
 static const int      NUM_MODELS = 8;
-static const string   READ_GROUP_TAG = "RG";
+static const std::string   READ_GROUP_TAG = "RG";
 static const double   DEFAULT_CONFIDENCE_INTERVAL = 0.9973;
 static const uint16_t DEFAULT_MIN_MAPQUALITY = 1;
 static const double   DEFAULT_UNUSEDMODEL_THRESHOLD = 0.1;
@@ -48,30 +47,30 @@ static const char COMMENT_CHAR     = '#';
 static const char EQUAL_CHAR       = '=';
 static const char TAB_CHAR         = '\t';
 
-static const string WHITESPACE_CHARS = " \t\n";
-static const string TRUE_KEYWORD     = "true";
-static const string FALSE_KEYWORD    = "false";
+static const std::string WHITESPACE_CHARS = " \t\n";
+static const std::string TRUE_KEYWORD     = "true";
+static const std::string FALSE_KEYWORD    = "false";
 
 // field counts
 static const size_t NUM_OPTIONS_FIELDS    = 2;
 static const size_t NUM_READGROUPS_FIELDS = 7;
 
 // header strings
-static const string INPUT_TOKEN      = "[Input]";
-static const string OPTIONS_TOKEN    = "[Options]";
-static const string READGROUPS_TOKEN = "[ReadGroups]";
+static const std::string INPUT_TOKEN      = "[Input]";
+static const std::string OPTIONS_TOKEN    = "[Options]";
+static const std::string READGROUPS_TOKEN = "[ReadGroups]";
 
 // option keywords
-static const string OPTION_CONFIDENCEINTERVAL   = "ConfidenceInterval";
-static const string OPTION_MINIMUMMAPQUALITY    = "MinimumMapQuality";
-static const string OPTION_UNUSEDMODELTHRESHOLD = "UnusedModelThreshold";
-static const string OPTION_FORCEMARKREADGROUPS  = "ForceMarkReadGroups";
+static const std::string OPTION_CONFIDENCEINTERVAL   = "ConfidenceInterval";
+static const std::string OPTION_MINIMUMMAPQUALITY    = "MinimumMapQuality";
+static const std::string OPTION_UNUSEDMODELTHRESHOLD = "UnusedModelThreshold";
+static const std::string OPTION_FORCEMARKREADGROUPS  = "ForceMarkReadGroups";
 
 // other string constants
-static const string RG_FIELD_DESCRIPTION =
+static const std::string RG_FIELD_DESCRIPTION =
     "#<name> <medianFL> <minFL> <maxFL> <topModelID> <nextTopModelID> <isAmbiguous?>";
 
-static const string MODEL_DESCRIPTION =
+static const std::string MODEL_DESCRIPTION =
     "# ------------- Model Types Description ---------------\n"
     "#\n"
     "#   ID     Position              Orientation           \n"
@@ -89,8 +88,8 @@ static const string MODEL_DESCRIPTION =
 // unique readname file constants
 // --------------------------------------------------------------------------
 
-static const string READNAME_FILE_SUFFIX = ".uniq_names.txt";
-static const string DEFAULT_READNAME_FILE = "bt_resolve_TEMP" + READNAME_FILE_SUFFIX;
+static const std::string READNAME_FILE_SUFFIX = ".uniq_names.txt";
+static const std::string DEFAULT_READNAME_FILE = "bt_resolve_TEMP" + READNAME_FILE_SUFFIX;
 
 // --------------------------------------------------------------------------
 // ModelType implementation
@@ -99,7 +98,7 @@ struct ModelType {
 
     // data members
     uint16_t ID;
-    vector<int32_t> FragmentLengths;
+    std::vector<int32_t> FragmentLengths;
 
     // ctor
     ModelType(const uint16_t id)
@@ -110,11 +109,11 @@ struct ModelType {
     }
 
     // convenience access to internal fragment lengths vector
-    vector<int32_t>::iterator begin(void) { return FragmentLengths.begin(); }
-    vector<int32_t>::const_iterator begin(void) const { return FragmentLengths.begin(); }
+    std::vector<int32_t>::iterator begin(void) { return FragmentLengths.begin(); }
+    std::vector<int32_t>::const_iterator begin(void) const { return FragmentLengths.begin(); }
     void clear(void) { FragmentLengths.clear(); }
-    vector<int32_t>::iterator end(void) { return FragmentLengths.end(); }
-    vector<int32_t>::const_iterator end(void) const { return FragmentLengths.end(); }
+    std::vector<int32_t>::iterator end(void) { return FragmentLengths.end(); }
+    std::vector<int32_t>::const_iterator end(void) const { return FragmentLengths.end(); }
     void push_back(const int32_t& x) { FragmentLengths.push_back(x); }
     size_t size(void) const { return FragmentLengths.size(); }
 
@@ -166,8 +165,8 @@ struct ReadGroupResolver {
     uint16_t NextTopModelId;
     bool IsAmbiguous;
     bool HasData;
-    vector<ModelType> Models;
-    map<string, bool> ReadNames;
+    std::vector<ModelType> Models;
+    std::map<std::string, bool> ReadNames;
 
     // ctor
     ReadGroupResolver(void);
@@ -177,7 +176,7 @@ struct ReadGroupResolver {
     bool IsValidOrientation(const BamAlignment& al) const;
 
     // select 2 best models based on observed data
-    void DetermineTopModels(const string& readGroupName);
+    void DetermineTopModels(const std::string& readGroupName);
 
     // static settings
     static double ConfidenceInterval;
@@ -215,7 +214,7 @@ bool ReadGroupResolver::IsValidOrientation(const BamAlignment& al) const {
     return ( currentModelId == TopModelId || currentModelId == NextTopModelId );
 }
 
-void ReadGroupResolver::DetermineTopModels(const string& readGroupName) {
+void ReadGroupResolver::DetermineTopModels(const std::string& readGroupName) {
 
     // sort models (from most common to least common)
     sort( Models.begin(), Models.end(), std::greater<ModelType>() );
@@ -233,9 +232,9 @@ void ReadGroupResolver::DetermineTopModels(const string& readGroupName) {
                                              Models[6].size() + Models[7].size();    
     const double unusedPercentage = (double)unusedModelCountSum / (double)activeModelCountSum;
     if ( unusedPercentage > UnusedModelThreshold ) {
-        cerr << "WARNING: " << readGroupName << " does not have clearly defined 'top models'" << endl
+        std::cerr << "WARNING: " << readGroupName << " does not have clearly defined 'top models'" << std::endl
              << "         The fraction of alignments in bottom 6 models (" << unusedPercentage
-             << ") exceeds threshold: " << UnusedModelThreshold << endl;
+             << ") exceeds threshold: " << UnusedModelThreshold << std::endl;
         IsAmbiguous = true;
     }
 
@@ -252,13 +251,13 @@ void ReadGroupResolver::DetermineTopModels(const string& readGroupName) {
     bool isSolidPair = ( isModel1Top && isModel8Top ? true : false );
 
     if ( !isMatePair && !isPairedEnd && !isSolidPair ) {
-        cerr << "WARNING: Found a non-standard alignment model configuration. " << endl
+        std::cerr << "WARNING: Found a non-standard alignment model configuration. " << std::endl
              << "         Using alignment models " << TopModelId << " & " << NextTopModelId
-             << endl;
+             << std::endl;
     }
 
     // store only the fragments from the best alignment models, then sort
-    vector<int32_t> fragments;
+    std::vector<int32_t> fragments;
     fragments.reserve( Models[0].size() + Models[1].size() );
     fragments.insert( fragments.end(), Models[0].begin(), Models[0].end() );
     fragments.insert( fragments.end(), Models[1].begin(), Models[1].end() );
@@ -317,10 +316,10 @@ struct ResolveTool::ResolveSettings {
     bool HasUnusedModelThreshold;
 
     // I/O filenames
-    string InputBamFilename;
-    string OutputBamFilename;
-    string StatsFilename;
-    string ReadNamesFilename; //  ** N.B. - Only used internally, not set from cmdline **
+    std::string InputBamFilename;
+    std::string OutputBamFilename;
+    std::string StatsFilename;
+    std::string ReadNamesFilename; //  ** N.B. - Only used internally, not set from cmdline **
 
     // resolve options
     double   ConfidenceInterval;
@@ -362,12 +361,12 @@ struct ResolveTool::ReadNamesFileReader {
     // main reader interface
     public:
         void Close(void);
-        bool Open(const string& filename);
-        bool Read(map<string, ReadGroupResolver>& readGroups);
+        bool Open(const std::string& filename);
+        bool Read(std::map<std::string, ReadGroupResolver>& readGroups);
 
     // data members
     private:
-        ifstream m_stream;
+        std::ifstream m_stream;
 };
 
 void ResolveTool::ReadNamesFileReader::Close(void) {
@@ -375,27 +374,27 @@ void ResolveTool::ReadNamesFileReader::Close(void) {
         m_stream.close();
 }
 
-bool ResolveTool::ReadNamesFileReader::Open(const string& filename) {
+bool ResolveTool::ReadNamesFileReader::Open(const std::string& filename) {
 
     // make sure stream is fresh
     Close();
 
     // attempt to open filename, return status
-    m_stream.open(filename.c_str(), ifstream::in);
+    m_stream.open(filename.c_str(), std::ifstream::in);
     return m_stream.good();
 }
 
-bool ResolveTool::ReadNamesFileReader::Read(map<string, ReadGroupResolver>& readGroups) {
+bool ResolveTool::ReadNamesFileReader::Read(std::map<std::string, ReadGroupResolver>& readGroups) {
 
     // up-front sanity check
     if ( !m_stream.is_open() ) return false;
 
     // parse read names file
-    string line;
-    vector<string> fields;
-    map<string, ReadGroupResolver>::iterator rgIter;
-    map<string, ReadGroupResolver>::iterator rgEnd = readGroups.end();
-    while ( getline(m_stream, line) ) {
+    std::string line;
+    std::vector<std::string> fields;
+    std::map<std::string, ReadGroupResolver>::iterator rgIter;
+    std::map<std::string, ReadGroupResolver>::iterator rgEnd = readGroups.end();
+    while ( std::getline(m_stream, line) ) {
 
         // skip if empty line
         if ( line.empty() ) continue;
@@ -410,7 +409,7 @@ bool ResolveTool::ReadNamesFileReader::Read(map<string, ReadGroupResolver>& read
         ReadGroupResolver& resolver = (*rgIter).second;
 
         // store read name with resolver
-        resolver.ReadNames.insert( make_pair(fields[1], true) ) ;
+        resolver.ReadNames.insert( std::make_pair(fields[1], true) ) ;
     }
 
     // if here, return success
@@ -429,12 +428,12 @@ struct ResolveTool::ReadNamesFileWriter {
     // main reader interface
     public:
         void Close(void);
-        bool Open(const string& filename);
-        void Write(const string& readGroupName, const string& readName);
+        bool Open(const std::string& filename);
+        void Write(const std::string& readGroupName, const std::string& readName);
 
     // data members
     private:
-        ofstream m_stream;
+        std::ofstream m_stream;
 };
 
 void ResolveTool::ReadNamesFileWriter::Close(void) {
@@ -442,20 +441,20 @@ void ResolveTool::ReadNamesFileWriter::Close(void) {
         m_stream.close();
 }
 
-bool ResolveTool::ReadNamesFileWriter::Open(const string& filename) {
+bool ResolveTool::ReadNamesFileWriter::Open(const std::string& filename) {
 
     // make sure stream is fresh
     Close();
 
     // attempt to open filename, return status
-    m_stream.open(filename.c_str(), ofstream::out);
+    m_stream.open(filename.c_str(), std::ofstream::out);
     return m_stream.good();
 }
 
-void ResolveTool::ReadNamesFileWriter::Write(const string& readGroupName,
-                                             const string& readName)
+void ResolveTool::ReadNamesFileWriter::Write(const std::string& readGroupName,
+                                             const std::string& readName)
 {
-    m_stream << readGroupName << TAB_CHAR << readName << endl;
+    m_stream << readGroupName << TAB_CHAR << readName << std::endl;
 }
 
 // --------------------------------------------------------------------------
@@ -471,22 +470,22 @@ struct ResolveTool::StatsFileReader {
     // main reader interface
     public:
         void Close(void);
-        bool Open(const string& filename);
+        bool Open(const std::string& filename);
         bool Read(ResolveTool::ResolveSettings* settings,
-                  map<string, ReadGroupResolver>& readGroups);
+                  std::map<std::string, ReadGroupResolver>& readGroups);
 
     // internal methods
     private:
-        bool IsComment(const string& line) const;
-        bool IsWhitespace(const string& line) const;
-        bool ParseInputLine(const string& line);
-        bool ParseOptionLine(const string& line, ResolveTool::ResolveSettings* settings);
-        bool ParseReadGroupLine(const string& line, map<string, ReadGroupResolver>& readGroups);
-        string SkipCommentsAndWhitespace(void);
+        bool IsComment(const std::string& line) const;
+        bool IsWhitespace(const std::string& line) const;
+        bool ParseInputLine(const std::string& line);
+        bool ParseOptionLine(const std::string& line, ResolveTool::ResolveSettings* settings);
+        bool ParseReadGroupLine(const std::string& line, std::map<std::string, ReadGroupResolver>& readGroups);
+        std::string SkipCommentsAndWhitespace(void);
 
     // data members
     private:
-        ifstream m_stream;
+        std::ifstream m_stream;
 
         enum State { None = 0
                    , InInput
@@ -499,41 +498,41 @@ void ResolveTool::StatsFileReader::Close(void) {
         m_stream.close();
 }
 
-bool ResolveTool::StatsFileReader::IsComment(const string& line) const {
+bool ResolveTool::StatsFileReader::IsComment(const std::string& line) const {
     assert( !line.empty() );
     return ( line.at(0) == COMMENT_CHAR );
 }
 
-bool ResolveTool::StatsFileReader::IsWhitespace(const string& line) const {
+bool ResolveTool::StatsFileReader::IsWhitespace(const std::string& line) const {
     if ( line.empty() )
         return true;
     return ( isspace(line.at(0)) );
 }
 
-bool ResolveTool::StatsFileReader::Open(const string& filename) {
+bool ResolveTool::StatsFileReader::Open(const std::string& filename) {
 
     // make sure stream is fresh
     Close();
 
     // attempt to open filename, return status
-    m_stream.open(filename.c_str(), ifstream::in);
+    m_stream.open(filename.c_str(), std::ifstream::in);
     return m_stream.good();
 }
 
-bool ResolveTool::StatsFileReader::ParseInputLine(const string& /*line*/) {
+bool ResolveTool::StatsFileReader::ParseInputLine(const std::string& /*line*/) {
     // input lines are ignored (for now at least), tool will use input from command line
     return true;
 }
 
-bool ResolveTool::StatsFileReader::ParseOptionLine(const string& line,
+bool ResolveTool::StatsFileReader::ParseOptionLine(const std::string& line,
                                                    ResolveTool::ResolveSettings* settings)
 {
     // split line into option, value
-    vector<string> fields = Utilities::Split(line, EQUAL_CHAR);
+    std::vector<std::string> fields = Utilities::Split(line, EQUAL_CHAR);
     if ( fields.size() != NUM_OPTIONS_FIELDS )
         return false;
-    const string& option = fields.at(0);
-    stringstream value(fields.at(1));
+    const std::string& option = fields.at(0);
+    std::stringstream value(fields.at(1));
 
     // -----------------------------------
     // handle option based on keyword
@@ -566,24 +565,24 @@ bool ResolveTool::StatsFileReader::ParseOptionLine(const string& line,
     }
 
     // otherwise unknown option
-    cerr << "bamtools resolve ERROR - unrecognized option: " << option << " in stats file" << endl;
+    std::cerr << "bamtools resolve ERROR - unrecognized option: " << option << " in stats file" << std::endl;
     return false;
 }
 
-bool ResolveTool::StatsFileReader::ParseReadGroupLine(const string& line,
-                                                      map<string, ReadGroupResolver>& readGroups)
+bool ResolveTool::StatsFileReader::ParseReadGroupLine(const std::string& line,
+                                                      std::map<std::string, ReadGroupResolver>& readGroups)
 {
     // split read group data in to fields
-    vector<string> fields = Utilities::Split(line, WHITESPACE_CHARS);
+    std::vector<std::string> fields = Utilities::Split(line, WHITESPACE_CHARS);
     if ( fields.size() != NUM_READGROUPS_FIELDS ) return false;
 
     // retrieve RG name
-    const string& name = fields.at(0);
+    const std::string& name = fields.at(0);
 
     // populate RG's 'resolver' data
     ReadGroupResolver resolver;
 
-    stringstream dataStream;
+    std::stringstream dataStream;
     dataStream.str(fields.at(1));
     dataStream >> resolver.MedianFragmentLength;
     dataStream.clear();
@@ -607,12 +606,12 @@ bool ResolveTool::StatsFileReader::ParseReadGroupLine(const string& line,
     resolver.IsAmbiguous = ( fields.at(6) == TRUE_KEYWORD );
 
     // store RG entry and return success
-    readGroups.insert( make_pair(name, resolver) );
+    readGroups.insert( std::make_pair(name, resolver) );
     return true;
 }
 
 bool ResolveTool::StatsFileReader::Read(ResolveTool::ResolveSettings* settings,
-                                        map<string, ReadGroupResolver>& readGroups)
+                                        std::map<std::string, ReadGroupResolver>& readGroups)
 {
     // up-front sanity checks
     if ( !m_stream.is_open() || settings == 0 )
@@ -625,7 +624,7 @@ bool ResolveTool::StatsFileReader::Read(ResolveTool::ResolveSettings* settings,
     State currentState = StatsFileReader::None;
 
     // read stats file
-    string line = SkipCommentsAndWhitespace();
+    std::string line = SkipCommentsAndWhitespace();
     while ( !line.empty() ) {
 
         bool foundError = false;
@@ -662,12 +661,12 @@ bool ResolveTool::StatsFileReader::Read(ResolveTool::ResolveSettings* settings,
     return true;
 }
 
-string ResolveTool::StatsFileReader::SkipCommentsAndWhitespace(void) {
-    string line;
+std::string ResolveTool::StatsFileReader::SkipCommentsAndWhitespace(void) {
+    std::string line;
     do {
         if ( m_stream.eof() )
-            return string();
-        getline(m_stream, line);
+            return std::string();
+        std::getline(m_stream, line);
     } while ( IsWhitespace(line) || IsComment(line) );
     return line;
 }
@@ -685,20 +684,20 @@ struct ResolveTool::StatsFileWriter {
     // main reader interface
     public:
         void Close(void);
-        bool Open(const string& filename);
+        bool Open(const std::string& filename);
         bool Write(ResolveTool::ResolveSettings* settings,
-                   const map<string, ReadGroupResolver>& readGroups);
+                   const std::map<std::string, ReadGroupResolver>& readGroups);
 
     // internal methods
     private:
         void WriteHeader(void);
         void WriteInput(ResolveTool::ResolveSettings* settings);
         void WriteOptions(ResolveTool::ResolveSettings* settings);
-        void WriteReadGroups(const map<string, ReadGroupResolver>& readGroups);
+        void WriteReadGroups(const std::map<std::string, ReadGroupResolver>& readGroups);
 
     // data members
     private:
-        ofstream m_stream;
+        std::ofstream m_stream;
 };
 
 void ResolveTool::StatsFileWriter::Close(void) {
@@ -706,18 +705,18 @@ void ResolveTool::StatsFileWriter::Close(void) {
         m_stream.close();
 }
 
-bool ResolveTool::StatsFileWriter::Open(const string& filename) {
+bool ResolveTool::StatsFileWriter::Open(const std::string& filename) {
 
     // make sure stream is fresh
     Close();
 
     // attempt to open filename, return status
-    m_stream.open(filename.c_str(), ofstream::out);
+    m_stream.open(filename.c_str(), std::ofstream::out);
     return m_stream.good();
 }
 
 bool ResolveTool::StatsFileWriter::Write(ResolveTool::ResolveSettings* settings,
-                                         const map<string, ReadGroupResolver>& readGroups)
+                                         const std::map<std::string, ReadGroupResolver>& readGroups)
 {
     // return failure if file not open
     if ( !m_stream.is_open() )
@@ -736,7 +735,7 @@ bool ResolveTool::StatsFileWriter::Write(ResolveTool::ResolveSettings* settings,
 void ResolveTool::StatsFileWriter::WriteHeader(void) {
 
     // stringify current bamtools version
-    stringstream versionStream("");
+    std::stringstream versionStream;
     versionStream << "v"
                   << BAMTOOLS_VERSION_MAJOR << "."
                   << BAMTOOLS_VERSION_MINOR << "."
@@ -747,10 +746,10 @@ void ResolveTool::StatsFileWriter::WriteHeader(void) {
     // # MODEL DESCRIPTION - see above for actual text
     // \n
 
-    m_stream << COMMENT_CHAR << " bamtools resolve (" << versionStream.str() << ")" << endl
-             << COMMENT_CHAR << endl
+    m_stream << COMMENT_CHAR << " bamtools resolve (" << versionStream.str() << ")" << std::endl
+             << COMMENT_CHAR << std::endl
              << MODEL_DESCRIPTION
-             << endl;
+             << std::endl;
 }
 
 void ResolveTool::StatsFileWriter::WriteInput(ResolveTool::ResolveSettings* settings) {
@@ -759,9 +758,9 @@ void ResolveTool::StatsFileWriter::WriteInput(ResolveTool::ResolveSettings* sett
     // filename
     // \n
 
-    m_stream << INPUT_TOKEN << endl
-             << settings->InputBamFilename << endl
-             << endl;
+    m_stream << INPUT_TOKEN << std::endl
+             << settings->InputBamFilename << std::endl
+             << std::endl;
 }
 
 void ResolveTool::StatsFileWriter::WriteOptions(ResolveTool::ResolveSettings* settings) {
@@ -773,26 +772,26 @@ void ResolveTool::StatsFileWriter::WriteOptions(ResolveTool::ResolveSettings* se
     // UnusedModelThreshold=<double>
     // \n
 
-    m_stream << OPTIONS_TOKEN << endl
-             << OPTION_CONFIDENCEINTERVAL   << EQUAL_CHAR << settings->ConfidenceInterval << endl
-             << OPTION_FORCEMARKREADGROUPS  << EQUAL_CHAR << boolalpha << settings->HasForceMarkReadGroups << endl
-             << OPTION_MINIMUMMAPQUALITY    << EQUAL_CHAR << settings->MinimumMapQuality << endl
-             << OPTION_UNUSEDMODELTHRESHOLD << EQUAL_CHAR << settings->UnusedModelThreshold << endl
-             << endl;
+    m_stream << OPTIONS_TOKEN << std::endl
+             << OPTION_CONFIDENCEINTERVAL   << EQUAL_CHAR << settings->ConfidenceInterval << std::endl
+             << OPTION_FORCEMARKREADGROUPS  << EQUAL_CHAR << std::boolalpha << settings->HasForceMarkReadGroups << std::endl
+             << OPTION_MINIMUMMAPQUALITY    << EQUAL_CHAR << settings->MinimumMapQuality << std::endl
+             << OPTION_UNUSEDMODELTHRESHOLD << EQUAL_CHAR << settings->UnusedModelThreshold << std::endl
+             << std::endl;
 }
 
-void ResolveTool::StatsFileWriter::WriteReadGroups(const map<string, ReadGroupResolver>& readGroups) {
+void ResolveTool::StatsFileWriter::WriteReadGroups(const std::map<std::string, ReadGroupResolver>& readGroups) {
 
     // [ReadGroups]
     // #<name> <medianFL> <minFL> <maxFL> <topModelID> <nextTopModelID> <isAmbiguous?>
-    m_stream << READGROUPS_TOKEN << endl
-             << RG_FIELD_DESCRIPTION << endl;
+    m_stream << READGROUPS_TOKEN << std::endl
+             << RG_FIELD_DESCRIPTION << std::endl;
 
     // iterate over read groups
-    map<string, ReadGroupResolver>::const_iterator rgIter = readGroups.begin();
-    map<string, ReadGroupResolver>::const_iterator rgEnd  = readGroups.end();
+    std::map<std::string, ReadGroupResolver>::const_iterator rgIter = readGroups.begin();
+    std::map<std::string, ReadGroupResolver>::const_iterator rgEnd  = readGroups.end();
     for ( ; rgIter != rgEnd; ++rgIter ) {
-        const string& name = (*rgIter).first;
+        const std::string& name = (*rgIter).first;
         const ReadGroupResolver& resolver = (*rgIter).second;
 
         // skip if read group has no data
@@ -806,12 +805,12 @@ void ResolveTool::StatsFileWriter::WriteReadGroups(const map<string, ReadGroupRe
                  << resolver.MaxFragmentLength << TAB_CHAR
                  << resolver.TopModelId << TAB_CHAR
                  << resolver.NextTopModelId << TAB_CHAR
-                 << boolalpha << resolver.IsAmbiguous
-                 << endl;
+                 << std::boolalpha << resolver.IsAmbiguous
+                 << std::endl;
     }
 
     // extra newline at end
-    m_stream << endl;
+    m_stream << std::endl;
 }
 
 // --------------------------------------------------------------------------
@@ -832,7 +831,7 @@ struct ResolveTool::ResolveToolPrivate {
 
     // internal methods
     private:
-        bool CheckSettings(vector<string>& errors);
+        bool CheckSettings(std::vector<std::string>& errors);
         bool MakeStats(void);
         void ParseHeader(const SamHeader& header);
         bool ReadStatsFile(void);
@@ -843,10 +842,10 @@ struct ResolveTool::ResolveToolPrivate {
     // data members
     private:
         ResolveTool::ResolveSettings* m_settings;
-        map<string, ReadGroupResolver> m_readGroups;
+        std::map<std::string, ReadGroupResolver> m_readGroups;
 };
 
-bool ResolveTool::ResolveToolPrivate::CheckSettings(vector<string>& errors) {
+bool ResolveTool::ResolveToolPrivate::CheckSettings(std::vector<std::string>& errors) {
 
     // ensure clean slate
     errors.clear();
@@ -938,8 +937,8 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
     // open our BAM reader
     BamReader bamReader;
     if ( !bamReader.Open(m_settings->InputBamFilename) ) {
-        cerr << "bamtools resolve ERROR: could not open input BAM file: "
-             << m_settings->InputBamFilename << endl;
+        std::cerr << "bamtools resolve ERROR: could not open input BAM file: "
+             << m_settings->InputBamFilename << std::endl;
         return false;
     }
 
@@ -950,17 +949,17 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
     // open ReadNamesFileWriter
     ResolveTool::ReadNamesFileWriter readNamesWriter;
     if ( !readNamesWriter.Open(m_settings->ReadNamesFilename) ) {
-        cerr << "bamtools resolve ERROR: could not open (temp) output read names file: "
-             << m_settings->ReadNamesFilename << endl;
+        std::cerr << "bamtools resolve ERROR: could not open (temp) output read names file: "
+             << m_settings->ReadNamesFilename << std::endl;
         bamReader.Close();
         return false;
     }
 
     // read through BAM file
     BamAlignment al;
-    string readGroup("");
-    map<string, ReadGroupResolver>::iterator rgIter;
-    map<string, bool>::iterator readNameIter;
+    std::string readGroup;
+    std::map<std::string, ReadGroupResolver>::iterator rgIter;
+    std::map<std::string, bool>::iterator readNameIter;
     while ( bamReader.GetNextAlignmentCore(al) ) {
 
         // skip if alignment is not paired, mapped, nor mate is mapped
@@ -980,8 +979,8 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
         // look up resolver for read group
         rgIter = m_readGroups.find(readGroup);
         if ( rgIter == m_readGroups.end() )  {
-            cerr << "bamtools resolve ERROR - unable to calculate stats, unknown read group encountered: "
-                 << readGroup << endl;
+            std::cerr << "bamtools resolve ERROR - unable to calculate stats, unknown read group encountered: "
+                 << readGroup << std::endl;
             bamReader.Close();
             return false;
         }
@@ -1014,7 +1013,7 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
         }
 
         // if read name not found, store new entry
-        else resolver.ReadNames.insert( make_pair(al.Name, isCurrentMateUnique) );
+        else resolver.ReadNames.insert( std::make_pair(al.Name, isCurrentMateUnique) );
     }
 
     // close files
@@ -1022,9 +1021,9 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
     bamReader.Close();
 
     // iterate back through read groups
-    map<string, ReadGroupResolver>::iterator rgEnd  = m_readGroups.end();
+    std::map<std::string, ReadGroupResolver>::iterator rgEnd  = m_readGroups.end();
     for ( rgIter = m_readGroups.begin(); rgIter != rgEnd; ++rgIter ) {
-        const string& name = (*rgIter).first;
+        const std::string& name = (*rgIter).first;
         ReadGroupResolver& resolver = (*rgIter).second;
 
         // calculate acceptable orientation & insert sizes for this read group
@@ -1046,7 +1045,7 @@ void ResolveTool::ResolveToolPrivate::ParseHeader(const SamHeader& header) {
     SamReadGroupConstIterator rgEnd  = header.ReadGroups.ConstEnd();
     for ( ; rgIter != rgEnd; ++rgIter ) {
         const SamReadGroup& rg = (*rgIter);
-        m_readGroups.insert( make_pair(rg.ID, ReadGroupResolver()) );
+        m_readGroups.insert( std::make_pair(rg.ID, ReadGroupResolver()) );
     }
 }
 
@@ -1059,15 +1058,15 @@ bool ResolveTool::ResolveToolPrivate::ReadStatsFile(void) {
     // attempt to open stats file
     ResolveTool::StatsFileReader statsReader;
     if ( !statsReader.Open(m_settings->StatsFilename) ) {
-        cerr << "bamtools resolve ERROR - could not open stats file: "
-             << m_settings->StatsFilename << " for reading" << endl;
+        std::cerr << "bamtools resolve ERROR - could not open stats file: "
+             << m_settings->StatsFilename << " for reading" << std::endl;
         return false;
     }
 
     // attempt to read stats data
     if ( !statsReader.Read(m_settings, m_readGroups) ) {
-        cerr << "bamtools resolve ERROR - could not parse stats file: "
-             << m_settings->StatsFilename << " for data" << endl;
+        std::cerr << "bamtools resolve ERROR - could not parse stats file: "
+             << m_settings->StatsFilename << " for data" << std::endl;
         return false;
     }
 
@@ -1094,15 +1093,15 @@ void ResolveTool::ResolveToolPrivate::ResolveAlignment(BamAlignment& al) {
 
     // get read group from alignment
     // empty string if not found, this is OK - we handle empty read group case
-    string readGroupName("");
+    std::string readGroupName;
     al.GetTag(READ_GROUP_TAG, readGroupName);
 
     // look up read group's 'resolver'
-    map<string, ReadGroupResolver>::iterator rgIter = m_readGroups.find(readGroupName);
+    std::map<std::string, ReadGroupResolver>::iterator rgIter = m_readGroups.find(readGroupName);
     if ( rgIter == m_readGroups.end() ) {
-        cerr << "bamtools resolve ERROR - read group found that was not in header: "
-             << readGroupName << endl;
-        exit(1);
+        std::cerr << "bamtools resolve ERROR - read group found that was not in header: "
+             << readGroupName << std::endl;
+        std::exit(EXIT_FAILURE);
     }
     const ReadGroupResolver& resolver = (*rgIter).second;
 
@@ -1113,7 +1112,7 @@ void ResolveTool::ResolveToolPrivate::ResolveAlignment(BamAlignment& al) {
     if ( !resolver.IsValidInsertSize(al) ) return;
 
     // quit check if alignment is not a "candidate proper pair"
-    map<string, bool>::const_iterator readNameIter;
+    std::map<std::string, bool>::const_iterator readNameIter;
     readNameIter = resolver.ReadNames.find(al.Name);
     if ( readNameIter == resolver.ReadNames.end() )
         return;
@@ -1127,15 +1126,15 @@ bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
     // open file containing read names of candidate proper pairs
     ResolveTool::ReadNamesFileReader readNamesReader;
     if ( !readNamesReader.Open(m_settings->ReadNamesFilename) ) {
-        cerr << "bamtools resolve ERROR: could not open (temp) inputput read names file: "
-             << m_settings->ReadNamesFilename << endl;
+        std::cerr << "bamtools resolve ERROR: could not open (temp) inputput read names file: "
+             << m_settings->ReadNamesFilename << std::endl;
         return false;
     }
 
     // parse read names (matching with corresponding read groups)
     if ( !readNamesReader.Read(m_readGroups) ) {
-        cerr << "bamtools resolve ERROR: could not read candidate read names from file: "
-             << m_settings->ReadNamesFilename << endl;
+        std::cerr << "bamtools resolve ERROR: could not read candidate read names from file: "
+             << m_settings->ReadNamesFilename << std::endl;
         readNamesReader.Close();
         return false;
     }
@@ -1143,15 +1142,15 @@ bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
     // close read name file reader & delete temp file
     readNamesReader.Close();
     if ( remove(m_settings->ReadNamesFilename.c_str()) != 0 ) {
-        cerr << "bamtools resolve WARNING: could not delete temp file: "
-             << m_settings->ReadNamesFilename << endl;
+        std::cerr << "bamtools resolve WARNING: could not delete temp file: "
+             << m_settings->ReadNamesFilename << std::endl;
     }
 
     // open our BAM reader
     BamReader reader;
     if ( !reader.Open(m_settings->InputBamFilename) ) {
-        cerr << "bamtools resolve ERROR: could not open input BAM file: "
-             << m_settings->InputBamFilename << endl;
+        std::cerr << "bamtools resolve ERROR: could not open input BAM file: "
+             << m_settings->InputBamFilename << std::endl;
         return false;
     }
 
@@ -1169,8 +1168,8 @@ bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
     BamWriter writer;
     writer.SetCompressionMode(compressionMode);
     if ( !writer.Open(m_settings->OutputBamFilename, header, references) ) {
-        cerr << "bamtools resolve ERROR: could not open "
-             << m_settings->OutputBamFilename << " for writing." << endl;
+        std::cerr << "bamtools resolve ERROR: could not open "
+             << m_settings->OutputBamFilename << " for writing." << std::endl;
         reader.Close();
         return false;
     }
@@ -1192,18 +1191,18 @@ bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
 bool ResolveTool::ResolveToolPrivate::Run(void) {
 
     // verify that command line settings are acceptable
-    vector<string> errors;
+    std::vector<std::string> errors;
     if ( !CheckSettings(errors) ) {
-        cerr << "bamtools resolve ERROR - invalid settings: " << endl;
-        vector<string>::const_iterator errorIter = errors.begin();
-        vector<string>::const_iterator errorEnd  = errors.end();
+        std::cerr << "bamtools resolve ERROR - invalid settings: " << std::endl;
+        std::vector<std::string>::const_iterator errorIter = errors.begin();
+        std::vector<std::string>::const_iterator errorEnd  = errors.end();
         for ( ; errorIter != errorEnd; ++errorIter )
-            cerr << (*errorIter) << endl;
+            std::cerr << (*errorIter) << std::endl;
         return false;
     }
 
     // initialize read group map with default (empty name) read group
-    m_readGroups.insert( make_pair<string, ReadGroupResolver>("", ReadGroupResolver()) );
+    m_readGroups.insert( std::make_pair("", ReadGroupResolver()) );
 
     // init readname filename
     // uses (adjusted) stats filename if provided (req'd for makeStats, markPairs modes; optional for twoPass)
@@ -1216,14 +1215,14 @@ bool ResolveTool::ResolveToolPrivate::Run(void) {
 
         // generate stats data
         if ( !MakeStats() ) {
-            cerr << "bamtools resolve ERROR - could not generate stats" << endl;
+            std::cerr << "bamtools resolve ERROR - could not generate stats" << std::endl;
             return false;
         }
 
         // write stats to file
         if ( !WriteStatsFile() ) {
-            cerr << "bamtools resolve ERROR - could not write stats file: "
-                 << m_settings->StatsFilename << endl;
+            std::cerr << "bamtools resolve ERROR - could not write stats file: "
+                 << m_settings->StatsFilename << std::endl;
             return false;
         }
     }
@@ -1233,14 +1232,14 @@ bool ResolveTool::ResolveToolPrivate::Run(void) {
 
         // read stats from file
         if ( !ReadStatsFile() ) {
-            cerr << "bamtools resolve ERROR - could not read stats file: "
-                 << m_settings->StatsFilename << endl;
+            std::cerr << "bamtools resolve ERROR - could not read stats file: "
+                 << m_settings->StatsFilename << std::endl;
             return false;
         }
 
         // do paired-end resolution
         if ( !ResolvePairs() ) {
-            cerr << "bamtools resolve ERROR - could not resolve pairs" << endl;
+            std::cerr << "bamtools resolve ERROR - could not resolve pairs" << std::endl;
             return false;
         }
     }
@@ -1250,7 +1249,7 @@ bool ResolveTool::ResolveToolPrivate::Run(void) {
 
         // generate stats data
         if ( !MakeStats() ) {
-            cerr << "bamtools resolve ERROR - could not generate stats" << endl;
+            std::cerr << "bamtools resolve ERROR - could not generate stats" << std::endl;
             return false;
         }
 
@@ -1260,13 +1259,13 @@ bool ResolveTool::ResolveToolPrivate::Run(void) {
             // write stats to file
             // emit warning if write fails, but paired-end resolution should be allowed to proceed
             if ( !WriteStatsFile() )
-                cerr << "bamtools resolve WARNING - could not write stats file: "
-                     << m_settings->StatsFilename << endl;
+                std::cerr << "bamtools resolve WARNING - could not write stats file: "
+                     << m_settings->StatsFilename << std::endl;
         }
 
         // do paired-end resolution
         if ( !ResolvePairs() ) {
-            cerr << "bamtools resolve ERROR - could not resolve pairs" << endl;
+            std::cerr << "bamtools resolve ERROR - could not resolve pairs" << std::endl;
             return false;
         }
     }
@@ -1284,15 +1283,15 @@ bool ResolveTool::ResolveToolPrivate::WriteStatsFile(void) {
     // attempt to open stats file
     ResolveTool::StatsFileWriter statsWriter;
     if ( !statsWriter.Open(m_settings->StatsFilename) ) {
-        cerr << "bamtools resolve ERROR - could not open stats file: "
-             << m_settings->StatsFilename << " for writing" << endl;
+        std::cerr << "bamtools resolve ERROR - could not open stats file: "
+             << m_settings->StatsFilename << " for writing" << std::endl;
         return false;
     }
 
     // attempt to write stats data
     if ( !statsWriter.Write(m_settings, m_readGroups) ) {
-        cerr << "bamtools resolve ERROR - could not write stats file: "
-             << m_settings->StatsFilename << " for data" << endl;
+        std::cerr << "bamtools resolve ERROR - could not write stats file: "
+             << m_settings->StatsFilename << " for data" << std::endl;
         return false;
     }
 
@@ -1309,39 +1308,39 @@ ResolveTool::ResolveTool(void)
     , m_impl(0)
 {
     // set description texts
-    const string programDescription = "resolves paired-end reads (marking the IsProperPair flag as needed)";
-    const string programUsage = "<mode> [options] [-in <filename>] [-out <filename> | [-forceCompression] ] [-stats <filename>]";
-    const string inputBamDescription = "the input BAM file(s)";
-    const string outputBamDescription = "the output BAM file";
-    const string statsFileDescription = "input/output stats file, depending on selected mode (see below). "
+    const std::string programDescription = "resolves paired-end reads (marking the IsProperPair flag as needed)";
+    const std::string programUsage = "<mode> [options] [-in <filename>] [-out <filename> | [-forceCompression] ] [-stats <filename>]";
+    const std::string inputBamDescription = "the input BAM file(s)";
+    const std::string outputBamDescription = "the output BAM file";
+    const std::string statsFileDescription = "input/output stats file, depending on selected mode (see below). "
             "This file is human-readable, storing fragment length data generated per read group, as well as "
             "the options used to configure the -makeStats mode";
-    const string forceCompressionDescription = "if results are sent to stdout (like when piping to another tool), "
+    const std::string forceCompressionDescription = "if results are sent to stdout (like when piping to another tool), "
             "default behavior is to leave output uncompressed."
             "Use this flag to override and force compression. This feature is disabled in -makeStats mode.";
-    const string makeStatsDescription = "generates a fragment-length stats file from the input BAM. "
+    const std::string makeStatsDescription = "generates a fragment-length stats file from the input BAM. "
             "Data is written to file specified using the -stats option. "
             "MarkPairs Mode Settings are DISABLED.";
-    const string markPairsDescription = "generates an output BAM with alignments marked with proper-pair status. "
+    const std::string markPairsDescription = "generates an output BAM with alignments marked with proper-pair status. "
             "Stats data is read from file specified using the -stats option. "
             "MakeStats Mode Settings are DISABLED";
-    const string twoPassDescription = "combines the -makeStats & -markPairs modes into a single command. "
+    const std::string twoPassDescription = "combines the -makeStats & -markPairs modes into a single command. "
             "However, due to the two-pass nature of paired-end resolution, piping BAM data via stdin is DISABLED. "
             "You must supply an explicit input BAM file. Output BAM may be piped to stdout, however, if desired. "
             "All MakeStats & MarkPairs Mode Settings are available. "
             "The intermediate stats file is not necessary, but if the -stats options is used, then one will be generated. "
             "You may find this useful for documentation purposes.";
-    const string minMapQualDescription = "minimum map quality. Used in -makeStats mode as a heuristic for determining a mate's "
+    const std::string minMapQualDescription = "minimum map quality. Used in -makeStats mode as a heuristic for determining a mate's "
             "uniqueness. Used in -markPairs mode as a filter for marking candidate proper pairs.";
-    const string confidenceIntervalDescription = "confidence interval. Set min/max fragment lengths such that we capture "
+    const std::string confidenceIntervalDescription = "confidence interval. Set min/max fragment lengths such that we capture "
             "this fraction of pairs";
-    const string unusedModelThresholdDescription = "unused model threshold. The resolve tool considers 8 possible orientation models "
+    const std::string unusedModelThresholdDescription = "unused model threshold. The resolve tool considers 8 possible orientation models "
             "for pairs. The top 2 are selected for later use when actually marking alignments. This value determines the "
             "cutoff for marking a read group as ambiguous. Meaning that if the ratio of the number of alignments from bottom 6 models "
             "to the top 2 is greater than this threshold, then the read group is flagged as ambiguous. By default, NO alignments "
             "from ambiguous read groups will be marked as proper pairs. You may override this behavior with the -force option "
             "in -markPairs mode";
-    const string forceMarkDescription = "forces all read groups to be marked according to their top 2 'orientation models'. "
+    const std::string forceMarkDescription = "forces all read groups to be marked according to their top 2 'orientation models'. "
             "When generating stats, the 2 (out of 8 possible) models with the most observations are chosen as the top models for each read group. "
             "If the remaining 6 models account for more than some threshold ([default=10%], see -umt), then the read group is marked as ambiguous. "
             "The default behavior is that for an ambiguous read group, NONE of its alignments are marked as proper-pairs. "

--- a/src/toolkit/bamtools_revert.cpp
+++ b/src/toolkit/bamtools_revert.cpp
@@ -17,11 +17,10 @@ using namespace BamTools;
 
 #include <iostream>
 #include <string>
-using namespace std;
 
 namespace BamTools {
 
-static const string OQ_TAG = "OQ";
+static const std::string OQ_TAG = "OQ";
 
 } // namespace BamTools;
 
@@ -38,8 +37,8 @@ struct RevertTool::RevertSettings {
     bool IsKeepQualities;
 
     // filenames
-    string InputFilename;
-    string OutputFilename;
+    std::string InputFilename;
+    std::string OutputFilename;
     
     // constructor
     RevertSettings(void)
@@ -87,7 +86,7 @@ void RevertTool::RevertToolPrivate::RevertAlignment(BamAlignment& al) {
 
     // replace Qualities with OQ contents, if requested
     if ( !m_settings->IsKeepQualities ) {
-        string originalQualities;
+        std::string originalQualities;
         if ( al.GetTag(OQ_TAG, originalQualities) ) {
             al.Qualities = originalQualities;
             al.RemoveTag(OQ_TAG);
@@ -104,13 +103,13 @@ bool RevertTool::RevertToolPrivate::Run(void) {
     // opens the BAM file without checking for indexes
     BamReader reader;
     if ( !reader.Open(m_settings->InputFilename) ) {
-        cerr << "bamtools revert ERROR: could not open " << m_settings->InputFilename
-             << " for reading... Aborting." << endl;
+        std::cerr << "bamtools revert ERROR: could not open " << m_settings->InputFilename
+             << " for reading... Aborting." << std::endl;
         return false;
     }
 
     // get BAM file metadata
-    const string& headerText = reader.GetHeaderText();
+    const std::string& headerText = reader.GetHeaderText();
     const RefVector& references = reader.GetReferenceData();
     
     // determine compression mode for BamWriter
@@ -123,8 +122,8 @@ bool RevertTool::RevertToolPrivate::Run(void) {
     BamWriter writer;
     writer.SetCompressionMode(compressionMode);
     if ( !writer.Open(m_settings->OutputFilename, headerText, references) ) {
-        cerr << "bamtools revert ERROR: could not open " << m_settings->OutputFilename
-             << " for writing... Aborting." << endl;
+        std::cerr << "bamtools revert ERROR: could not open " << m_settings->OutputFilename
+             << " for writing... Aborting." << std::endl;
         reader.Close();
         return false;
     }

--- a/src/toolkit/bamtools_split.cpp
+++ b/src/toolkit/bamtools_split.cpp
@@ -23,30 +23,29 @@ using namespace BamTools;
 #include <sstream>
 #include <string>
 #include <vector>
-using namespace std;
 
 namespace BamTools {
   
 // string constants
-static const string SPLIT_MAPPED_TOKEN    = ".MAPPED";
-static const string SPLIT_UNMAPPED_TOKEN  = ".UNMAPPED";
-static const string SPLIT_PAIRED_TOKEN    = ".PAIRED_END";
-static const string SPLIT_SINGLE_TOKEN    = ".SINGLE_END";
-static const string SPLIT_REFERENCE_TOKEN = ".REF_";
-static const string SPLIT_TAG_TOKEN       = ".TAG_";
+static const std::string SPLIT_MAPPED_TOKEN    = ".MAPPED";
+static const std::string SPLIT_UNMAPPED_TOKEN  = ".UNMAPPED";
+static const std::string SPLIT_PAIRED_TOKEN    = ".PAIRED_END";
+static const std::string SPLIT_SINGLE_TOKEN    = ".SINGLE_END";
+static const std::string SPLIT_REFERENCE_TOKEN = ".REF_";
+static const std::string SPLIT_TAG_TOKEN       = ".TAG_";
 
-string GetTimestampString(void) {
+std::string GetTimestampString(void) {
 
     // get human readable timestamp
     time_t currentTime;
     time(&currentTime);
-    stringstream timeStream("");
+    std::stringstream timeStream;
     timeStream << ctime(&currentTime);
 
     // convert whitespace to '_'
-    string timeString = timeStream.str();
+    std::string timeString = timeStream.str();
     size_t found = timeString.find(" ");
-    while (found != string::npos) {
+    while (found != std::string::npos) {
         timeString.replace(found, 1, "_");
         found = timeString.find(" ", found+1);
     }
@@ -55,7 +54,7 @@ string GetTimestampString(void) {
 
 // remove copy of filename without extension
 // (so /path/to/file.txt becomes /path/to/file )
-string RemoveFilenameExtension(const string& filename) {
+std::string RemoveFilenameExtension(const std::string& filename) {
     size_t found = filename.rfind(".");
     return filename.substr(0, found);
 }
@@ -79,12 +78,12 @@ struct SplitTool::SplitSettings {
     bool IsSplittingTag;
     
     // string args
-    string CustomOutputStub;
-    string CustomRefPrefix;
-    string CustomTagPrefix;
-    string InputFilename;
-    string TagToSplit;
-    string ListTagDelimiter;
+    std::string CustomOutputStub;
+    std::string CustomRefPrefix;
+    std::string CustomTagPrefix;
+    std::string InputFilename;
+    std::string TagToSplit;
+    std::string ListTagDelimiter;
     
     // constructor
     SplitSettings(void)
@@ -129,7 +128,7 @@ class SplitTool::SplitToolPrivate {
     private:
         // close & delete BamWriters in map
         template<typename T>
-        void CloseWriters(map<T, BamWriter*>& writers);
+        void CloseWriters(std::map<T, BamWriter*>& writers);
         // calculate output stub based on IO args given
         void DetermineOutputFilenameStub(void);
         // open our BamReader
@@ -157,9 +156,9 @@ class SplitTool::SplitToolPrivate {
     // data members
     private:
         SplitTool::SplitSettings* m_settings;
-        string m_outputFilenameStub;
+        std::string m_outputFilenameStub;
         BamReader m_reader;
-        string m_header;
+        std::string m_header;
         RefVector m_references;
 };
 
@@ -182,7 +181,7 @@ bool SplitTool::SplitToolPrivate::OpenReader(void) {
 
     // attempt to open BAM file
     if ( !m_reader.Open(m_settings->InputFilename) ) {
-        cerr << "bamtools split ERROR: could not open BAM file: " << m_settings->InputFilename << endl;
+        std::cerr << "bamtools split ERROR: could not open BAM file: " << m_settings->InputFilename << std::endl;
         return false;
     }
 
@@ -208,16 +207,16 @@ bool SplitTool::SplitToolPrivate::Run(void) {
     if ( m_settings->IsSplittingTag )       return SplitTag();
 
     // if we get here, no property was specified 
-    cerr << "bamtools split ERROR: no property given to split on... " << endl
-         << "Please use -mapped, -paired, -reference, or -tag TAG to specify desired split behavior." << endl;
+    std::cerr << "bamtools split ERROR: no property given to split on... " << std::endl
+         << "Please use -mapped, -paired, -reference, or -tag TAG to specify desired split behavior." << std::endl;
     return false;
 }    
 
 bool SplitTool::SplitToolPrivate::SplitMapped(void) {
     
     // set up splitting data structure
-    map<bool, BamWriter*> outputFiles;
-    map<bool, BamWriter*>::iterator writerIter;
+    std::map<bool, BamWriter*> outputFiles;
+    std::map<bool, BamWriter*>::iterator writerIter;
     
     // iterate through alignments
     BamAlignment al;
@@ -233,18 +232,18 @@ bool SplitTool::SplitToolPrivate::SplitMapped(void) {
         if ( writerIter == outputFiles.end() ) {
         
             // open new BamWriter
-            const string outputFilename = m_outputFilenameStub + ( isCurrentAlignmentMapped
+            const std::string outputFilename = m_outputFilenameStub + ( isCurrentAlignmentMapped
                                                                   ? SPLIT_MAPPED_TOKEN
                                                                   : SPLIT_UNMAPPED_TOKEN ) + ".bam";
             writer = new BamWriter;
             if ( !writer->Open(outputFilename, m_header, m_references) ) {
-                cerr << "bamtools split ERROR: could not open " << outputFilename
-                     << " for writing." << endl;
+                std::cerr << "bamtools split ERROR: could not open " << outputFilename
+                     << " for writing." << std::endl;
                 return false;
             }
           
             // store in map
-            outputFiles.insert( make_pair(isCurrentAlignmentMapped, writer) );
+            outputFiles.insert( std::make_pair(isCurrentAlignmentMapped, writer) );
         } 
         
         // else grab corresponding writer
@@ -265,8 +264,8 @@ bool SplitTool::SplitToolPrivate::SplitMapped(void) {
 bool SplitTool::SplitToolPrivate::SplitPaired(void) {
   
     // set up splitting data structure
-    map<bool, BamWriter*> outputFiles;
-    map<bool, BamWriter*>::iterator writerIter;
+    std::map<bool, BamWriter*> outputFiles;
+    std::map<bool, BamWriter*>::iterator writerIter;
     
     // iterate through alignments
     BamAlignment al;
@@ -282,18 +281,18 @@ bool SplitTool::SplitToolPrivate::SplitPaired(void) {
         if ( writerIter == outputFiles.end() ) {
         
             // open new BamWriter
-            const string outputFilename = m_outputFilenameStub + ( isCurrentAlignmentPaired
+            const std::string outputFilename = m_outputFilenameStub + ( isCurrentAlignmentPaired
                                                                   ? SPLIT_PAIRED_TOKEN
                                                                   : SPLIT_SINGLE_TOKEN ) + ".bam";
             writer = new BamWriter;
             if ( !writer->Open(outputFilename, m_header, m_references) ) {
-                cerr << "bamtool split ERROR: could not open " << outputFilename
-                     << " for writing." << endl;
+                std::cerr << "bamtool split ERROR: could not open " << outputFilename
+                     << " for writing." << std::endl;
                 return false;
             }
           
             // store in map
-            outputFiles.insert( make_pair(isCurrentAlignmentPaired, writer) );
+            outputFiles.insert( std::make_pair(isCurrentAlignmentPaired, writer) );
         } 
         
         // else grab corresponding writer
@@ -314,18 +313,18 @@ bool SplitTool::SplitToolPrivate::SplitPaired(void) {
 bool SplitTool::SplitToolPrivate::SplitReference(void) {
   
     // set up splitting data structure
-    map<int32_t, BamWriter*> outputFiles;
-    map<int32_t, BamWriter*>::iterator writerIter;
+    std::map<int32_t, BamWriter*> outputFiles;
+    std::map<int32_t, BamWriter*>::iterator writerIter;
     
     // determine reference prefix
-    string refPrefix = SPLIT_REFERENCE_TOKEN;
+    std::string refPrefix = SPLIT_REFERENCE_TOKEN;
     if ( m_settings->HasCustomRefPrefix )
         refPrefix = m_settings->CustomRefPrefix;
 
     // make sure prefix starts with '.'
     const size_t dotFound = refPrefix.find('.');
     if ( dotFound != 0 )
-        refPrefix = string(".") + refPrefix;
+        refPrefix = std::string(".") + refPrefix;
 
     // iterate through alignments
     BamAlignment al;
@@ -341,25 +340,25 @@ bool SplitTool::SplitToolPrivate::SplitReference(void) {
         if ( writerIter == outputFiles.end() ) {
         
             // fetch reference name for ID
-            string refName;
+            std::string refName;
             if ( currentRefId == -1 )
                 refName = "unmapped";
             else
                 refName = m_references.at(currentRefId).RefName;
 
             // construct new output filename
-            const string outputFilename = m_outputFilenameStub + refPrefix + refName + ".bam";
+            const std::string outputFilename = m_outputFilenameStub + refPrefix + refName + ".bam";
 
             // open new BamWriter
             writer = new BamWriter;
             if ( !writer->Open(outputFilename, m_header, m_references) ) {
-                cerr << "bamtools split ERROR: could not open " << outputFilename
-                     << " for writing." << endl;
+                std::cerr << "bamtools split ERROR: could not open " << outputFilename
+                     << " for writing." << std::endl;
                 return false;
             }
 
             // store in map
-            outputFiles.insert( make_pair(currentRefId, writer) );
+            outputFiles.insert( std::make_pair(currentRefId, writer) );
         } 
         
         // else grab corresponding writer
@@ -404,7 +403,7 @@ bool SplitTool::SplitToolPrivate::SplitTag(void) {
             case (Constants::BAM_TAG_TYPE_ASCII)  :
             case (Constants::BAM_TAG_TYPE_STRING) :
             case (Constants::BAM_TAG_TYPE_HEX)    :
-                return SplitTagImpl<string>(al);
+                return SplitTagImpl<std::string>(al);
 
             case (Constants::BAM_TAG_TYPE_ARRAY) : {
 
@@ -420,13 +419,13 @@ bool SplitTool::SplitToolPrivate::SplitTag(void) {
                     case (Constants::BAM_TAG_TYPE_UINT32) : return SplitListTagImpl<uint32_t>(al);
                     case (Constants::BAM_TAG_TYPE_FLOAT)  : return SplitListTagImpl<float>(al);
                     default:
-                        cerr << "bamtools split ERROR: array tag has unsupported element type: " << arrayTagType << endl;
+                        std::cerr << "bamtools split ERROR: array tag has unsupported element type: " << arrayTagType << std::endl;
                         return false;
                 }
             }
           
             default:
-                cerr << "bamtools split ERROR: unknown tag type encountered: " << tagType << endl;
+                std::cerr << "bamtools split ERROR: unknown tag type encountered: " << tagType << std::endl;
                 return false;
         }
     }
@@ -443,9 +442,9 @@ bool SplitTool::SplitToolPrivate::SplitTag(void) {
 
 // close BamWriters & delete pointers
 template<typename T>
-void SplitTool::SplitToolPrivate::CloseWriters(map<T, BamWriter*>& writers) {
+void SplitTool::SplitToolPrivate::CloseWriters(std::map<T, BamWriter*>& writers) {
   
-    typedef map<T, BamWriter*> WriterMap;
+    typedef std::map<T, BamWriter*> WriterMap;
     typedef typename WriterMap::iterator WriterMapIterator;
   
     // iterate over writers
@@ -471,8 +470,8 @@ void SplitTool::SplitToolPrivate::CloseWriters(map<T, BamWriter*>& writers) {
 template<typename T>
 bool SplitTool::SplitToolPrivate::SplitListTagImpl(BamAlignment& al) {
 
-    typedef vector<T> TagValueType;
-    typedef map<string, BamWriter*> WriterMap;
+    typedef std::vector<T> TagValueType;
+    typedef std::map<std::string, BamWriter*> WriterMap;
     typedef typename WriterMap::iterator WriterMapIterator;
 
     // set up splitting data structure
@@ -480,26 +479,26 @@ bool SplitTool::SplitToolPrivate::SplitListTagImpl(BamAlignment& al) {
     WriterMapIterator writerIter;
 
     // determine tag prefix
-    string tagPrefix = SPLIT_TAG_TOKEN;
+    std::string tagPrefix = SPLIT_TAG_TOKEN;
     if ( m_settings->HasCustomTagPrefix )
         tagPrefix = m_settings->CustomTagPrefix;
 
     // make sure prefix starts with '.'
     const size_t dotFound = tagPrefix.find('.');
     if ( dotFound != 0 )
-        tagPrefix = string(".") + tagPrefix;
+        tagPrefix = std::string(".") + tagPrefix;
 
-    const string tag = m_settings->TagToSplit;
+    const std::string tag = m_settings->TagToSplit;
     BamWriter* writer;
     TagValueType currentValue;
     while (m_reader.GetNextAlignment(al)) {
 
-        string listTagLabel;
+        std::string listTagLabel;
         if (!al.GetTag(tag, currentValue))
             listTagLabel = "none";
         else {
             // make list label from tag data
-            stringstream listTagLabelStream;
+            std::stringstream listTagLabelStream;
             typename TagValueType::const_iterator tagValueIter = currentValue.begin();
             typename TagValueType::const_iterator tagValueEnd  = currentValue.end();
             for (; tagValueIter != tagValueEnd; ++tagValueIter)
@@ -516,17 +515,17 @@ bool SplitTool::SplitToolPrivate::SplitListTagImpl(BamAlignment& al) {
         if (writerIter == outputFiles.end()) {
 
             // open new BamWriter, save first alignment
-            stringstream outputFilenameStream;
+            std::stringstream outputFilenameStream;
             outputFilenameStream << m_outputFilenameStub << tagPrefix << tag << "_" << listTagLabel << ".bam";
             writer = new BamWriter;
             if ( !writer->Open(outputFilenameStream.str(), m_header, m_references) ) {
-                cerr << "bamtools split ERROR: could not open " << outputFilenameStream.str()
-                     << " for writing." << endl;
+                std::cerr << "bamtools split ERROR: could not open " << outputFilenameStream.str()
+                     << " for writing." << std::endl;
                 return false;
             }
 
             // store in map
-            outputFiles.insert( make_pair(listTagLabel, writer) );
+            outputFiles.insert( std::make_pair(listTagLabel, writer) );
         }
 
         // else grab existing writer
@@ -547,7 +546,7 @@ template<typename T>
 bool SplitTool::SplitToolPrivate::SplitTagImpl(BamAlignment& al) {
   
     typedef T TagValueType;
-    typedef map<TagValueType, BamWriter*> WriterMap;
+    typedef std::map<TagValueType, BamWriter*> WriterMap;
     typedef typename WriterMap::iterator WriterMapIterator;
   
     // set up splitting data structure
@@ -555,19 +554,19 @@ bool SplitTool::SplitToolPrivate::SplitTagImpl(BamAlignment& al) {
     WriterMapIterator writerIter;
 
     // determine tag prefix
-    string tagPrefix = SPLIT_TAG_TOKEN;
+    std::string tagPrefix = SPLIT_TAG_TOKEN;
     if ( m_settings->HasCustomTagPrefix )
         tagPrefix = m_settings->CustomTagPrefix;
 
     // make sure prefix starts with '.'
     const size_t dotFound = tagPrefix.find('.');
     if ( dotFound != 0 )
-        tagPrefix = string(".") + tagPrefix;
+        tagPrefix = std::string(".") + tagPrefix;
 
     // local variables
-    const string tag = m_settings->TagToSplit;
+    const std::string tag = m_settings->TagToSplit;
     BamWriter* writer;
-    stringstream outputFilenameStream("");
+    std::stringstream outputFilenameStream;
     TagValueType currentValue;
     
     // retrieve first alignment tag value
@@ -577,14 +576,14 @@ bool SplitTool::SplitToolPrivate::SplitTagImpl(BamAlignment& al) {
         outputFilenameStream << m_outputFilenameStub << tagPrefix << tag << "_" << currentValue << ".bam";
         writer = new BamWriter;
         if ( !writer->Open(outputFilenameStream.str(), m_header, m_references) ) {
-            cerr << "bamtools split ERROR: could not open " << outputFilenameStream.str()
-                 << " for writing." << endl;
+            std::cerr << "bamtools split ERROR: could not open " << outputFilenameStream.str()
+                 << " for writing." << std::endl;
             return false;
         }
         writer->SaveAlignment(al);
         
         // store in map
-        outputFiles.insert( make_pair(currentValue, writer) );
+        outputFiles.insert( std::make_pair(currentValue, writer) );
         
         // reset stream
         outputFilenameStream.str("");
@@ -606,13 +605,13 @@ bool SplitTool::SplitToolPrivate::SplitTagImpl(BamAlignment& al) {
             outputFilenameStream << m_outputFilenameStub << tagPrefix << tag << "_" << currentValue << ".bam";
             writer = new BamWriter;
             if ( !writer->Open(outputFilenameStream.str(), m_header, m_references) ) {
-                cerr << "bamtool split ERROR: could not open " << outputFilenameStream.str()
-                     << " for writing." << endl;
+                std::cerr << "bamtool split ERROR: could not open " << outputFilenameStream.str()
+                     << " for writing." << std::endl;
                 return false;
             }
 
             // store in map
-            outputFiles.insert( make_pair(currentValue, writer) );
+            outputFiles.insert( std::make_pair(currentValue, writer) );
             
             // reset stream
             outputFilenameStream.str("");
@@ -642,9 +641,9 @@ SplitTool::SplitTool(void)
     , m_impl(0)
 {
     // set program details
-    const string name = "bamtools split";
-    const string description = "splits a BAM file on user-specified property, creating a new BAM output file for each value found";
-    const string args = "[-in <filename>] [-stub <filename stub>] < -mapped | -paired | -reference [-refPrefix <prefix>] | -tag <TAG> > ";
+    const std::string name = "bamtools split";
+    const std::string description = "splits a BAM file on user-specified property, creating a new BAM output file for each value found";
+    const std::string args = "[-in <filename>] [-stub <filename stub>] < -mapped | -paired | -reference [-refPrefix <prefix>] | -tag <TAG> > ";
     Options::SetProgramInfo(name, description, args);
     
     // set up options 

--- a/src/toolkit/bamtools_stats.cpp
+++ b/src/toolkit/bamtools_stats.cpp
@@ -21,7 +21,6 @@ using namespace BamTools;
 #include <numeric>
 #include <string>
 #include <vector>
-using namespace std;
 
 // ---------------------------------------------
 // StatsSettings implementation
@@ -34,8 +33,8 @@ struct StatsTool::StatsSettings {
     bool IsShowingInsertSizeSummary;
 
     // filenames
-    vector<string> InputFiles;
-    string InputFilelist;
+    std::vector<std::string> InputFiles;
+    std::string InputFilelist;
     
     // constructor
     StatsSettings(void)
@@ -61,7 +60,7 @@ struct StatsTool::StatsToolPrivate {
         
     // internal methods
     private:
-        bool CalculateMedian(vector<int>& data, double& median); 
+        bool CalculateMedian(std::vector<int>& data, double& median); 
         void PrintStats(void);
         void ProcessAlignment(const BamAlignment& al);
         
@@ -80,7 +79,7 @@ struct StatsTool::StatsToolPrivate {
         unsigned int m_numSingletons;
         unsigned int m_numFailedQC;
         unsigned int m_numDuplicates;
-        vector<int> m_insertSizes;
+        std::vector<int> m_insertSizes;
 };
 
 StatsTool::StatsToolPrivate::StatsToolPrivate(StatsTool::StatsSettings* settings)
@@ -103,7 +102,7 @@ StatsTool::StatsToolPrivate::StatsToolPrivate(StatsTool::StatsSettings* settings
 
 // median is of type double because in the case of even number of data elements,
 // we need to return the average of middle 2 elements
-bool StatsTool::StatsToolPrivate::CalculateMedian(vector<int>& data, double& median) { 
+bool StatsTool::StatsToolPrivate::CalculateMedian(std::vector<int>& data, double& median) { 
   
     // skip if data empty
     if ( data.empty() )
@@ -111,7 +110,7 @@ bool StatsTool::StatsToolPrivate::CalculateMedian(vector<int>& data, double& med
 
     // find middle element
     size_t middleIndex = data.size() / 2;
-    vector<int>::iterator target = data.begin() + middleIndex;
+    std::vector<int>::iterator target = data.begin() + middleIndex;
     nth_element(data.begin(), target, data.end());
     
     // odd number of elements
@@ -123,7 +122,7 @@ bool StatsTool::StatsToolPrivate::CalculateMedian(vector<int>& data, double& med
     // even number of elements
     else {
         double rightTarget = (double)(*target);
-        vector<int>::iterator leftTarget = target - 1;
+        std::vector<int>::iterator leftTarget = target - 1;
         nth_element(data.begin(), leftTarget, data.end());
         median = (double)((rightTarget+*leftTarget)/2.0);
         return true;
@@ -133,25 +132,25 @@ bool StatsTool::StatsToolPrivate::CalculateMedian(vector<int>& data, double& med
 // print BAM file alignment stats
 void StatsTool::StatsToolPrivate::PrintStats(void) {
   
-    cout << endl;
-    cout << "**********************************************" << endl;
-    cout << "Stats for BAM file(s): " << endl;
-    cout << "**********************************************" << endl;
-    cout << endl;
-    cout << "Total reads:       " << m_numReads << endl;
-    cout << "Mapped reads:      " << m_numMapped << "\t(" << ((float)m_numMapped/m_numReads)*100 << "%)" << endl;
-    cout << "Forward strand:    " << m_numForwardStrand << "\t(" << ((float)m_numForwardStrand/m_numReads)*100 << "%)" << endl;
-    cout << "Reverse strand:    " << m_numReverseStrand << "\t(" << ((float)m_numReverseStrand/m_numReads)*100 << "%)" << endl;
-    cout << "Failed QC:         " << m_numFailedQC << "\t(" << ((float)m_numFailedQC/m_numReads)*100 << "%)" << endl;
-    cout << "Duplicates:        " << m_numDuplicates << "\t(" << ((float)m_numDuplicates/m_numReads)*100 << "%)" << endl;
-    cout << "Paired-end reads:  " << m_numPaired << "\t(" << ((float)m_numPaired/m_numReads)*100 << "%)" << endl;
+    std::cout << std::endl;
+    std::cout << "**********************************************" << std::endl;
+    std::cout << "Stats for BAM file(s): " << std::endl;
+    std::cout << "**********************************************" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Total reads:       " << m_numReads << std::endl;
+    std::cout << "Mapped reads:      " << m_numMapped << "\t(" << ((float)m_numMapped/m_numReads)*100 << "%)" << std::endl;
+    std::cout << "Forward strand:    " << m_numForwardStrand << "\t(" << ((float)m_numForwardStrand/m_numReads)*100 << "%)" << std::endl;
+    std::cout << "Reverse strand:    " << m_numReverseStrand << "\t(" << ((float)m_numReverseStrand/m_numReads)*100 << "%)" << std::endl;
+    std::cout << "Failed QC:         " << m_numFailedQC << "\t(" << ((float)m_numFailedQC/m_numReads)*100 << "%)" << std::endl;
+    std::cout << "Duplicates:        " << m_numDuplicates << "\t(" << ((float)m_numDuplicates/m_numReads)*100 << "%)" << std::endl;
+    std::cout << "Paired-end reads:  " << m_numPaired << "\t(" << ((float)m_numPaired/m_numReads)*100 << "%)" << std::endl;
     
     if ( m_numPaired != 0 ) {
-        cout << "'Proper-pairs':    " << m_numProperPair << "\t(" << ((float)m_numProperPair/m_numPaired)*100 << "%)" << endl;
-        cout << "Both pairs mapped: " << m_numBothMatesMapped << "\t(" << ((float)m_numBothMatesMapped/m_numPaired)*100 << "%)" << endl;
-        cout << "Read 1:            " << m_numFirstMate << endl;
-        cout << "Read 2:            " << m_numSecondMate << endl;
-        cout << "Singletons:        " << m_numSingletons << "\t(" << ((float)m_numSingletons/m_numPaired)*100 << "%)" << endl;
+        std::cout << "'Proper-pairs':    " << m_numProperPair << "\t(" << ((float)m_numProperPair/m_numPaired)*100 << "%)" << std::endl;
+        std::cout << "Both pairs mapped: " << m_numBothMatesMapped << "\t(" << ((float)m_numBothMatesMapped/m_numPaired)*100 << "%)" << std::endl;
+        std::cout << "Read 1:            " << m_numFirstMate << std::endl;
+        std::cout << "Read 2:            " << m_numSecondMate << std::endl;
+        std::cout << "Singletons:        " << m_numSingletons << "\t(" << ((float)m_numSingletons/m_numPaired)*100 << "%)" << std::endl;
     }
     
     if ( m_settings->IsShowingInsertSizeSummary ) {
@@ -159,14 +158,14 @@ void StatsTool::StatsToolPrivate::PrintStats(void) {
         double avgInsertSize = 0.0;
         if ( !m_insertSizes.empty() ) {
             avgInsertSize = ( accumulate(m_insertSizes.begin(), m_insertSizes.end(), 0.0) / (double)m_insertSizes.size() );
-            cout << "Average insert size (absolute value): " << avgInsertSize << endl;
+            std::cout << "Average insert size (absolute value): " << avgInsertSize << std::endl;
         }
         
         double medianInsertSize = 0.0;
         if ( CalculateMedian(m_insertSizes, medianInsertSize) )
-            cout << "Median insert size (absolute value): " << medianInsertSize << endl;
+            std::cout << "Median insert size (absolute value): " << medianInsertSize << std::endl;
     }
-    cout << endl;
+    std::cout << std::endl;
 }
 
 // use current input alignment to update BAM file alignment stats
@@ -227,21 +226,21 @@ bool StatsTool::StatsToolPrivate::Run() {
     // add files in the filelist to the input file list
     if ( m_settings->HasInputFilelist ) {
 
-        ifstream filelist(m_settings->InputFilelist.c_str(), ios::in);
+        std::ifstream filelist(m_settings->InputFilelist.c_str(), std::ios::in);
         if ( !filelist.is_open() ) {
-            cerr << "bamtools stats ERROR: could not open input BAM file list... Aborting." << endl;
+            std::cerr << "bamtools stats ERROR: could not open input BAM file list... Aborting." << std::endl;
             return false;
         }
 
-        string line;
-        while ( getline(filelist, line) )
+        std::string line;
+        while ( std::getline(filelist, line) )
             m_settings->InputFiles.push_back(line);
     }
 
     // open the BAM files
     BamMultiReader reader;
     if ( !reader.Open(m_settings->InputFiles) ) {
-        cerr << "bamtools stats ERROR: could not open input BAM file(s)... Aborting." << endl;
+        std::cerr << "bamtools stats ERROR: could not open input BAM file(s)... Aborting." << std::endl;
         reader.Close();
         return false;
     }

--- a/src/utils/bamtools_filter_engine.h
+++ b/src/utils/bamtools_filter_engine.h
@@ -218,7 +218,7 @@ template<typename FilterChecker>
 inline void FilterEngine<FilterChecker>::buildDefaultRuleString(void) {
   
     // set up temp string stream 
-    std::stringstream ruleStream("");
+    std::stringstream ruleStream;
   
     // get first filterName
     FilterMap::const_iterator mapIter = m_filters.begin();

--- a/src/utils/bamtools_options.cpp
+++ b/src/utils/bamtools_options.cpp
@@ -24,19 +24,18 @@ using namespace BamTools;
 #include <cstring>
 #include <iomanip>
 #include <sstream>
-using namespace std;
 
-string Options::m_programName;                   // the program name
-string Options::m_description;                   // the main description
-string Options::m_exampleArguments;              // the example arguments
-vector<OptionGroup> Options::m_optionGroups;     // stores the option groups
-map<string, OptionValue> Options::m_optionsMap;  // stores the options in a map
-const string Options::m_stdin  = "stdin";        // string representation of stdin
-const string Options::m_stdout = "stdout";       // string representation of stdout
+std::string Options::m_programName;                   // the program name
+std::string Options::m_description;                   // the main description
+std::string Options::m_exampleArguments;              // the example arguments
+std::vector<OptionGroup> Options::m_optionGroups;     // stores the option groups
+std::map<std::string, OptionValue> Options::m_optionsMap;  // stores the options in a map
+const std::string Options::m_stdin  = "stdin";        // string representation of stdin
+const std::string Options::m_stdout = "stdout";       // string representation of stdout
 
 // adds a simple option to the parser
-void Options::AddOption(const string& argument,
-                        const string& optionDescription,
+void Options::AddOption(const std::string& argument,
+                        const std::string& optionDescription,
                         bool& foundArgument,
                         OptionGroup* group)
 {
@@ -54,7 +53,7 @@ void Options::AddOption(const string& argument,
 }
 
 // creates an option group
-OptionGroup* Options::CreateOptionGroup(const string& groupName) {
+OptionGroup* Options::CreateOptionGroup(const std::string& groupName) {
     OptionGroup og;
     og.Name = groupName;
     m_optionGroups.push_back(og);
@@ -66,7 +65,7 @@ void Options::DisplayHelp(void) {
 
     // initialize
     char argumentBuffer[ARGUMENT_LENGTH + 1];
-    ostringstream sb;
+    std::ostringstream sb;
 
     char indentBuffer[MAX_LINE_LENGTH - DESC_LENGTH + 1];
     memset(indentBuffer, ' ', MAX_LINE_LENGTH - DESC_LENGTH);
@@ -78,8 +77,8 @@ void Options::DisplayHelp(void) {
     printf("%s", m_programName.c_str());
     printf(" %s\n\n", m_exampleArguments.c_str());
 
-    vector<Option>::const_iterator      optionIter;
-    vector<OptionGroup>::const_iterator groupIter;
+    std::vector<Option>::const_iterator      optionIter;
+    std::vector<OptionGroup>::const_iterator groupIter;
     for (groupIter = m_optionGroups.begin(); groupIter != m_optionGroups.end(); ++groupIter) {
         
         printf("%s:\n", groupIter->Name.c_str());
@@ -92,7 +91,7 @@ void Options::DisplayHelp(void) {
                 snprintf(argumentBuffer, ARGUMENT_LENGTH + 1, "  %s", optionIter->Argument.c_str());
             printf("%-35s ", argumentBuffer);
 
-            string description = optionIter->Description;
+            std::string description = optionIter->Description;
 
             // handle default values
             if (optionIter->HasDefaultValue) {
@@ -114,7 +113,7 @@ void Options::DisplayHelp(void) {
                 } else {
                     printf("ERROR: Found an unsupported data type for argument %s when casting the default value.\n",
                            optionIter->Argument.c_str());
-                    exit(1);
+                    std::exit(EXIT_FAILURE);
                 }
 
                 sb << "]";
@@ -153,20 +152,20 @@ void Options::DisplayHelp(void) {
 
     printf("Help:\n"); 
     printf("  --help, -h                        shows this help text\n");
-    exit(1);
+    std::exit(EXIT_FAILURE);
 }
 
 // parses the command line
 void Options::Parse(int argc, char* argv[], int offset) {
 
     // initialize
-    map<string, OptionValue>::const_iterator ovMapIter;
-    map<string, OptionValue>::const_iterator checkMapIter;
+    std::map<std::string, OptionValue>::const_iterator ovMapIter;
+    std::map<std::string, OptionValue>::const_iterator checkMapIter;
     const int LAST_INDEX = argc - 1;
-    ostringstream errorBuilder;
+    std::ostringstream errorBuilder;
     bool foundError = false;
     char* end_ptr = NULL;
-    const string ERROR_SPACER(7, ' ');
+    const std::string ERROR_SPACER(7, ' ');
 
     // check if we should show the help menu
     bool showHelpMenu = false;
@@ -184,7 +183,7 @@ void Options::Parse(int argc, char* argv[], int offset) {
     // check each argument
     for (int i = offset+1; i < argc; i++) {
       
-        const string argument = argv[i];
+        const std::string argument = argv[i];
         ovMapIter = m_optionsMap.find(argument);
 
         if (ovMapIter == m_optionsMap.end()) {
@@ -200,7 +199,7 @@ void Options::Parse(int argc, char* argv[], int offset) {
                 if (i < LAST_INDEX) {
 
                     // check if the next argument is really a command line option
-                    const string val = argv[i + 1]; 
+                    const std::string val = argv[i + 1]; 
                     checkMapIter = m_optionsMap.find(val);
 
                     if (checkMapIter == m_optionsMap.end()) {
@@ -227,25 +226,25 @@ void Options::Parse(int argc, char* argv[], int offset) {
                             const float f = (float)strtod(val.c_str(), &end_ptr);
                             float* varValue = (float*)ovMapIter->second.pValue;
                             *varValue = f;
-                        } else if (ovMapIter->second.VariantValue.is_type<string>()) {
-                            string* pStringValue = (string*)ovMapIter->second.pValue;
+                        } else if (ovMapIter->second.VariantValue.is_type<std::string>()) {
+                            std::string* pStringValue = (std::string*)ovMapIter->second.pValue;
                             *pStringValue = val;
-                        } else if (ovMapIter->second.VariantValue.is_type<vector<string> >()) {
-                            vector<string>* pVectorValue = (vector<string>*)ovMapIter->second.pValue;
+                        } else if (ovMapIter->second.VariantValue.is_type<std::vector<std::string> >()) {
+                            std::vector<std::string>* pVectorValue = (std::vector<std::string>*)ovMapIter->second.pValue;
                             pVectorValue->push_back(val);
                         } else {
                             printf("ERROR: Found an unsupported data type for argument %s when parsing the arguments.\n",
                                    argument.c_str());
-                            exit(1);
+                            std::exit(EXIT_FAILURE);
                         }
                     } else {
                         errorBuilder << ERROR_SPACER << "The argument (" << argument
-                                     << ") expects a value, but none was found." << endl;
+                                     << ") expects a value, but none was found." << std::endl;
                         foundError = true;
                     }
                 } else {
                     errorBuilder << ERROR_SPACER << "The argument (" << argument
-                                 << ") expects a value, but none was found." << endl;
+                                 << ") expects a value, but none was found." << std::endl;
                     foundError = true;
                 }
             }
@@ -256,7 +255,7 @@ void Options::Parse(int argc, char* argv[], int offset) {
     for (ovMapIter = m_optionsMap.begin(); ovMapIter != m_optionsMap.end(); ++ovMapIter) {
         if (ovMapIter->second.IsRequired && !*ovMapIter->second.pFoundArgument) {
             errorBuilder << ERROR_SPACER << ovMapIter->second.ValueTypeDescription
-                         << " was not specified. Please use the " << ovMapIter->first << " parameter." << endl;
+                         << " was not specified. Please use the " << ovMapIter->first << " parameter." << std::endl;
             foundError = true;
         }
     }
@@ -266,14 +265,14 @@ void Options::Parse(int argc, char* argv[], int offset) {
         printf("ERROR: Some problems were encountered when parsing the command line options:\n");
         printf("%s\n", errorBuilder.str().c_str());
         printf("For a complete list of command line options, type \"%s help %s\"\n", argv[0], argv[1]);
-        exit(1);
+        std::exit(EXIT_FAILURE);
     }
 }
 
 // sets the program info
-void Options::SetProgramInfo(const string& programName,
-                             const string& description,
-                             const string& arguments)
+void Options::SetProgramInfo(const std::string& programName,
+                             const std::string& description,
+                             const std::string& arguments)
 {
     m_programName      = programName;
     m_description      = description;
@@ -281,7 +280,7 @@ void Options::SetProgramInfo(const string& programName,
 }
 
 // return string representations of stdin
-const string& Options::StandardIn(void) { return m_stdin; }
+const std::string& Options::StandardIn(void) { return m_stdin; }
 
 // return string representations of stdout
-const string& Options::StandardOut(void) { return m_stdout; }
+const std::string& Options::StandardOut(void) { return m_stdout; }

--- a/src/utils/bamtools_pileup_engine.cpp
+++ b/src/utils/bamtools_pileup_engine.cpp
@@ -11,7 +11,6 @@
 using namespace BamTools;
 
 #include <iostream>
-using namespace std;
 
 // ---------------------------------------------
 // PileupEnginePrivate implementation
@@ -21,11 +20,11 @@ struct PileupEngine::PileupEnginePrivate {
     // data members
     int CurrentId;
     int CurrentPosition;
-    vector<BamAlignment> CurrentAlignments;
+    std::vector<BamAlignment> CurrentAlignments;
     PileupPosition CurrentPileupData;
     
     bool IsFirstAlignment;
-    vector<PileupVisitor*> Visitors;
+    std::vector<PileupVisitor*> Visitors;
   
     // ctor & dtor
     PileupEnginePrivate(void)
@@ -74,7 +73,7 @@ bool PileupEngine::PileupEnginePrivate::AddAlignment(const BamAlignment& al) {
         
         // if less than CurrentPosition - sorting error => ABORT
         else if ( al.Position < CurrentPosition ) {
-            cerr << "Pileup::Run() : Data not sorted correctly!" << endl;
+            std::cerr << "Pileup::Run() : Data not sorted correctly!" << std::endl;
             return false;
         }
         
@@ -90,7 +89,7 @@ bool PileupEngine::PileupEnginePrivate::AddAlignment(const BamAlignment& al) {
 
     // if reference ID less than CurrentId - sorting error => ABORT
     else if ( al.RefID < CurrentId ) {
-        cerr << "Pileup::Run() : Data not sorted correctly!" << endl;
+        std::cerr << "Pileup::Run() : Data not sorted correctly!" << std::endl;
         return false;
     }
 
@@ -119,8 +118,8 @@ void PileupEngine::PileupEnginePrivate::ApplyVisitors(void) {
     CreatePileupData();
   
     // apply all visitors to current alignment set
-    vector<PileupVisitor*>::const_iterator visitorIter = Visitors.begin();
-    vector<PileupVisitor*>::const_iterator visitorEnd  = Visitors.end();
+    std::vector<PileupVisitor*>::const_iterator visitorIter = Visitors.begin();
+    std::vector<PileupVisitor*>::const_iterator visitorEnd  = Visitors.end();
     for ( ; visitorIter != visitorEnd; ++visitorIter ) 
         (*visitorIter)->Visit(CurrentPileupData);
 }
@@ -170,8 +169,8 @@ void PileupEngine::PileupEnginePrivate::CreatePileupData(void) {
     CurrentPileupData.PileupAlignments.clear();
     
     // parse CIGAR data in remaining alignments 
-    vector<BamAlignment>::const_iterator alIter = CurrentAlignments.begin();
-    vector<BamAlignment>::const_iterator alEnd  = CurrentAlignments.end(); 
+    std::vector<BamAlignment>::const_iterator alIter = CurrentAlignments.begin();
+    std::vector<BamAlignment>::const_iterator alEnd  = CurrentAlignments.end(); 
     for ( ; alIter != alEnd; ++alIter )
         ParseAlignmentCigar( (*alIter) );
 }

--- a/src/utils/bamtools_utilities.cpp
+++ b/src/utils/bamtools_utilities.cpp
@@ -18,7 +18,6 @@ using namespace BamTools;
 #include <fstream>
 #include <iostream>
 #include <sstream>
-using namespace std;
 
 namespace BamTools {
   
@@ -33,17 +32,17 @@ const char REVCOMP_LOOKUP[] = {'T',  0,  'G', 'H',
 } // namespace BamTools 
   
 // returns true if 'source' contains 'pattern'
-bool Utilities::Contains(const string& source, const string& pattern) {
-    return ( source.find(pattern) != string::npos );
+bool Utilities::Contains(const std::string& source, const std::string& pattern) {
+    return ( source.find(pattern) != std::string::npos );
 }
 
 // returns true if 'source' contains 'c'
 bool Utilities::Contains(const std::string &source, const char c) {
-    return ( source.find(c) != string::npos );
+    return ( source.find(c) != std::string::npos );
 }
 
 // returns true if 'source' ends with 'pattern'
-bool Utilities::EndsWith(const string& source, const string& pattern) {
+bool Utilities::EndsWith(const std::string& source, const std::string& pattern) {
     return ( source.find(pattern) == (source.length() - pattern.length()) );
 }
 
@@ -53,14 +52,14 @@ bool Utilities::EndsWith(const std::string& source, const char c) {
 }
 
 // check if a file exists
-bool Utilities::FileExists(const string& filename) {
-    ifstream f(filename.c_str(), ifstream::in);
+bool Utilities::FileExists(const std::string& filename) {
+    std::ifstream f(filename.c_str(), std::ifstream::in);
     return !f.fail();
 }
 
 // Parses a region string, does validation (valid ID's, positions), stores in Region struct
 // Returns success (true/false)
-bool Utilities::ParseRegionString(const string& regionString,
+bool Utilities::ParseRegionString(const std::string& regionString,
                                   const BamReader& reader,
                                   BamRegion& region)
 {
@@ -75,8 +74,8 @@ bool Utilities::ParseRegionString(const string& regionString,
     size_t foundFirstColon = regionString.find(':');
     
     // store chrom strings, and numeric positions
-    string startChrom;
-    string stopChrom;
+    std::string startChrom;
+    std::string stopChrom;
     int startPos;
     int stopPos;
     
@@ -84,7 +83,7 @@ bool Utilities::ParseRegionString(const string& regionString,
     // going to use entire contents of requested chromosome 
     // just store entire region string as startChrom name
     // use BamReader methods to check if its valid for current BAM file
-    if ( foundFirstColon == string::npos ) {
+    if ( foundFirstColon == std::string::npos ) {
         startChrom = regionString;
         startPos   = 0;
         stopChrom  = regionString;
@@ -103,8 +102,8 @@ bool Utilities::ParseRegionString(const string& regionString,
         // no dots found
         // so we have a startPos but no range
         // store contents before colon as startChrom, after as startPos
-        if ( foundRangeDots == string::npos ) {
-            startPos   = atoi( regionString.substr(foundFirstColon+1).c_str() ); 
+        if ( foundRangeDots == std::string::npos ) {
+            startPos   = std::atoi( regionString.substr(foundFirstColon+1).c_str() ); 
             stopChrom  = startChrom;
             stopPos    = -1;
         } 
@@ -113,23 +112,23 @@ bool Utilities::ParseRegionString(const string& regionString,
         else {
           
             // store startPos between first colon and range dots ".."
-            startPos = atoi( regionString.substr(foundFirstColon+1, foundRangeDots-foundFirstColon-1).c_str() );
+            startPos = std::atoi( regionString.substr(foundFirstColon+1, foundRangeDots-foundFirstColon-1).c_str() );
           
             // look for second colon
             size_t foundSecondColon = regionString.find(':', foundRangeDots+1);
             
             // no second colon found
             // so we have a "standard" chrom:start..stop input format (on single chrom)
-            if ( foundSecondColon == string::npos ) {
+            if ( foundSecondColon == std::string::npos ) {
                 stopChrom  = startChrom;
-                stopPos    = atoi( regionString.substr(foundRangeDots+2).c_str() );
+                stopPos    = std::atoi( regionString.substr(foundRangeDots+2).c_str() );
             }
             
             // second colon found
             // so we have a range requested across 2 chrom's
             else {
                 stopChrom  = regionString.substr(foundRangeDots+2, foundSecondColon-(foundRangeDots+2));
-                stopPos    = atoi( regionString.substr(foundSecondColon+1).c_str() );
+                stopPos    = std::atoi( regionString.substr(foundSecondColon+1).c_str() );
             }
         }
     }
@@ -169,7 +168,7 @@ bool Utilities::ParseRegionString(const string& regionString,
 }
 
 // Same as ParseRegionString() above, but accepts a BamMultiReader
-bool Utilities::ParseRegionString(const string& regionString,
+bool Utilities::ParseRegionString(const std::string& regionString,
                                   const BamMultiReader& reader,
                                   BamRegion& region)
 {
@@ -184,8 +183,8 @@ bool Utilities::ParseRegionString(const string& regionString,
     size_t foundFirstColon = regionString.find(':');
     
     // store chrom strings, and numeric positions
-    string startChrom;
-    string stopChrom;
+    std::string startChrom;
+    std::string stopChrom;
     int startPos;
     int stopPos;
     
@@ -193,7 +192,7 @@ bool Utilities::ParseRegionString(const string& regionString,
     // going to use entire contents of requested chromosome 
     // just store entire region string as startChrom name
     // use BamReader methods to check if its valid for current BAM file
-    if ( foundFirstColon == string::npos ) {
+    if ( foundFirstColon == std::string::npos ) {
         startChrom = regionString;
         startPos   = 0;
         stopChrom  = regionString;
@@ -212,8 +211,8 @@ bool Utilities::ParseRegionString(const string& regionString,
         // no dots found
         // so we have a startPos but no range
         // store contents before colon as startChrom, after as startPos
-        if ( foundRangeDots == string::npos ) {
-            startPos   = atoi( regionString.substr(foundFirstColon+1).c_str() ); 
+        if ( foundRangeDots == std::string::npos ) {
+            startPos   = std::atoi( regionString.substr(foundFirstColon+1).c_str() ); 
             stopChrom  = startChrom;
             stopPos    = -1;
         } 
@@ -222,23 +221,23 @@ bool Utilities::ParseRegionString(const string& regionString,
         else {
           
             // store startPos between first colon and range dots ".."
-            startPos = atoi( regionString.substr(foundFirstColon+1, foundRangeDots-foundFirstColon-1).c_str() );
+            startPos = std::atoi( regionString.substr(foundFirstColon+1, foundRangeDots-foundFirstColon-1).c_str() );
           
             // look for second colon
             size_t foundSecondColon = regionString.find(':', foundRangeDots+1);
             
             // no second colon found
             // so we have a "standard" chrom:start..stop input format (on single chrom)
-            if ( foundSecondColon == string::npos ) {
+            if ( foundSecondColon == std::string::npos ) {
                 stopChrom  = startChrom;
-                stopPos    = atoi( regionString.substr(foundRangeDots+2).c_str() );
+                stopPos    = std::atoi( regionString.substr(foundRangeDots+2).c_str() );
             }
             
             // second colon found
             // so we have a range requested across 2 chrom's
             else {
                 stopChrom  = regionString.substr(foundRangeDots+2, foundSecondColon-(foundRangeDots+2));
-                stopPos    = atoi( regionString.substr(foundSecondColon+1).c_str() );
+                stopPos    = std::atoi( regionString.substr(foundSecondColon+1).c_str() );
             }
         }
     }
@@ -277,11 +276,11 @@ bool Utilities::ParseRegionString(const string& regionString,
     return true;
 }
 
-void Utilities::Reverse(string& sequence) {
+void Utilities::Reverse(std::string& sequence) {
     reverse(sequence.begin(), sequence.end());
 }
 
-void Utilities::ReverseComplement(string& sequence) {
+void Utilities::ReverseComplement(std::string& sequence) {
     
     // do complement, in-place
     size_t seqLength = sequence.length();
@@ -292,20 +291,20 @@ void Utilities::ReverseComplement(string& sequence) {
     Reverse(sequence);
 }
 
-vector<string> Utilities::Split(const string& source, const char delim) {
+std::vector<std::string> Utilities::Split(const std::string& source, const char delim) {
 
-    stringstream ss(source);
-    string field;
-    vector<string> fields;
+    std::stringstream ss(source);
+    std::string field;
+    std::vector<std::string> fields;
 
-    while ( getline(ss, field, delim) )
+    while ( std::getline(ss, field, delim) )
         fields.push_back(field);
     return fields;
 }
 
-vector<string> Utilities::Split(const string& source, const string& delims) {
+std::vector<std::string> Utilities::Split(const std::string& source, const std::string& delims) {
 
-    vector<string> fields;
+    std::vector<std::string> fields;
 
     char* tok;
     char* cchars = new char[source.size()+1];
@@ -323,7 +322,7 @@ vector<string> Utilities::Split(const string& source, const string& delims) {
 }
 
 // returns true if 'source' starts with 'pattern'
-bool Utilities::StartsWith(const string& source, const string& pattern) {
+bool Utilities::StartsWith(const std::string& source, const std::string& pattern) {
     return ( source.find(pattern) == 0 );
 }
 


### PR DESCRIPTION
* Prefer fully qualified identifiers to
  reduce possibility of future clashes.
* Also avoid some `std::string` and `std::stringstream`
  null-string initializations. ISO C++ guarantees
  that both classes yield empty but valid states at
  the point of definition.