### PR TITLE
Use idiomatic CMake VERSION variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,12 @@
 # CMake requirements
 cmake_minimum_required( VERSION 3.0 )
 
-# set project name
-project( BamTools LANGUAGES CXX )
+# allow setting project version in project()
+# https://cmake.org/cmake/help/v3.0/policy/CMP0048.html#policy:CMP0048
+cmake_policy( SET CMP0048 NEW )
+
+# set project name and version
+project( BamTools LANGUAGES CXX VERSION 2.4.1 )
 
 # on macOS, MACOSX_RPATH is enabled by default on more recent versions
 # of CMake. Disable this behaviour, and let user enable it if need be.
@@ -39,16 +43,11 @@ endmacro( ENSURE_OUT_OF_SOURCE_BUILD )
 
 ensure_out_of_source_build( "
   ${PROJECT_NAME} requires an out of source build.
-  $ mkdir build 
+  $ mkdir build
   $ cd build
   $ cmake ..
-  $ make 
+  $ make
 (or the Windows equivalent)\n" )
-
-# set BamTools version information
-set( BamTools_VERSION_MAJOR 2 )
-set( BamTools_VERSION_MINOR 4 )
-set( BamTools_VERSION_BUILD 1 )
 
 # define compiler flags for all code, copied from Autoconf's AC_SYS_LARGEFILE
 add_definitions( -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE )

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library( BamTools ${BamToolsAPISources} )
 # The SONAME is bumped on every version increment
 # as Bamtools does not yet guarantee a stable ABI
 set_target_properties( BamTools PROPERTIES
-                       SOVERSION "${BamTools_VERSION_MAJOR}.${BamTools_VERSION_MINOR}.${BamTools_VERSION_BUILD}"
+                       SOVERSION "${BamTools_VERSION}"
                        OUTPUT_NAME "bamtools" )
 target_link_libraries( BamTools ${APILibs} )
 install( TARGETS BamTools

--- a/src/bamtools.pc.in
+++ b/src/bamtools.pc.in
@@ -3,7 +3,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: BamTools
 Description: BamTools is a C++ library for reading and manipulating BAM files
-Version: @BamTools_VERSION_MAJOR@.@BamTools_VERSION_MINOR@.@BamTools_VERSION_BUILD@
+Version: @BamTools_VERSION@
 
 Libs: -L${libdir} -lbamtools
 Cflags: -I${includedir}

--- a/src/toolkit/bamtools.cpp
+++ b/src/toolkit/bamtools.cpp
@@ -130,7 +130,7 @@ int Version(void) {
     std::stringstream versionStream;
     versionStream << BAMTOOLS_VERSION_MAJOR << "."
                   << BAMTOOLS_VERSION_MINOR << "."
-                  << BAMTOOLS_VERSION_BUILD;
+                  << BAMTOOLS_VERSION_PATCH;
 
     std::cout << std::endl;
     std::cout << "bamtools " << versionStream.str() << std::endl;

--- a/src/toolkit/bamtools_resolve.cpp
+++ b/src/toolkit/bamtools_resolve.cpp
@@ -739,7 +739,7 @@ void ResolveTool::StatsFileWriter::WriteHeader(void) {
     versionStream << "v"
                   << BAMTOOLS_VERSION_MAJOR << "."
                   << BAMTOOLS_VERSION_MINOR << "."
-                  << BAMTOOLS_VERSION_BUILD;
+                  << BAMTOOLS_VERSION_PATCH;
 
     // # bamtools resolve (vX.Y.Z)
     // #

--- a/src/toolkit/bamtools_version.h.in
+++ b/src/toolkit/bamtools_version.h.in
@@ -14,7 +14,7 @@
 // These constants are defined to match the variables set in the build system. 
 #define BAMTOOLS_VERSION_MAJOR @BamTools_VERSION_MAJOR@
 #define BAMTOOLS_VERSION_MINOR @BamTools_VERSION_MINOR@
-#define BAMTOOLS_VERSION_BUILD @BamTools_VERSION_BUILD@
+#define BAMTOOLS_VERSION_PATCH @BamTools_VERSION_PATCH@
 
 #endif // BAMTOOLS_VERSION_H
 


### PR DESCRIPTION
* Easier to change
* Use standard CMake variables instead of
  inventing new ones.