### PR TITLE
Remove `(void)` function declarations

### DIFF
--- a/src/api/BamAlignment.cpp
+++ b/src/api/BamAlignment.cpp
@@ -75,10 +75,10 @@ using namespace BamTools;
     \brief name of BAM file which this alignment comes from
 */
 
-/*! \fn BamAlignment::BamAlignment(void)
+/*! \fn BamAlignment::BamAlignment()
     \brief constructor
 */
-BamAlignment::BamAlignment(void)
+BamAlignment::BamAlignment()
     : Length(0)
     , RefID(-1)
     , Position(-1)
@@ -113,12 +113,12 @@ BamAlignment::BamAlignment(const BamAlignment& other)
     , SupportData(other.SupportData)
 { }
 
-/*! \fn BamAlignment::~BamAlignment(void)
+/*! \fn BamAlignment::~BamAlignment()
     \brief destructor
 */
-BamAlignment::~BamAlignment(void) { }
+BamAlignment::~BamAlignment() { }
 
-/*! \fn bool BamAlignment::BuildCharData(void)
+/*! \fn bool BamAlignment::BuildCharData()
     \brief Populates alignment string fields (read name, bases, qualities, tag data).
 
     An alignment retrieved using BamReader::GetNextAlignmentCore() lacks this data.
@@ -130,7 +130,7 @@ BamAlignment::~BamAlignment(void) { }
 
     \return \c true if character data populated successfully (or was already available to begin with)
 */
-bool BamAlignment::BuildCharData(void) {
+bool BamAlignment::BuildCharData() {
 
     // skip if char data already parsed
     if ( !SupportData.HasCoreOnly )
@@ -516,7 +516,7 @@ int BamAlignment::GetEndPosition(bool usePadded, bool closedInterval) const {
     return alignEnd;
 }
 
-/*! \fn std::string BamAlignment::GetErrorString(void) const
+/*! \fn std::string BamAlignment::GetErrorString() const
     \brief Returns a human-readable description of the last error that occurred
 
     This method allows elimination of STDERR pollution. Developers of client code
@@ -524,7 +524,7 @@ int BamAlignment::GetEndPosition(bool usePadded, bool closedInterval) const {
 
     \return error description
 */
-std::string BamAlignment::GetErrorString(void) const {
+std::string BamAlignment::GetErrorString() const {
     return ErrorString;
 }
 
@@ -616,7 +616,7 @@ bool BamAlignment::GetSoftClips(std::vector<int>& clipSizes,
     return softClipFound;
 }
 
-/*! \fn std::vector<std::string> BamAlignment::GetTagNames(void) const
+/*! \fn std::vector<std::string> BamAlignment::GetTagNames() const
     \brief Retrieves the BAM tag names.
 
     When paired with GetTagType() and GetTag(), this method allows you
@@ -626,7 +626,7 @@ bool BamAlignment::GetSoftClips(std::vector<int>& clipSizes,
     \return \c vector containing all tag names found (empty if none available)
     \sa \samSpecURL for more details on reserved tag names, supported tag types, etc.
 */
-std::vector<std::string> BamAlignment::GetTagNames(void) const {
+std::vector<std::string> BamAlignment::GetTagNames() const {
 
     std::vector<std::string> result;
     if ( SupportData.HasCoreOnly || TagData.empty() )
@@ -734,80 +734,80 @@ bool BamAlignment::HasTag(const std::string& tag) const {
     return FindTag(tag, pTagData, tagDataLength, numBytesParsed);
 }
 
-/*! \fn bool BamAlignment::IsDuplicate(void) const
+/*! \fn bool BamAlignment::IsDuplicate() const
     \return \c true if this read is a PCR duplicate
 */
-bool BamAlignment::IsDuplicate(void) const {
+bool BamAlignment::IsDuplicate() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_DUPLICATE) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsFailedQC(void) const
+/*! \fn bool BamAlignment::IsFailedQC() const
     \return \c true if this read failed quality control
 */
-bool BamAlignment::IsFailedQC(void) const {
+bool BamAlignment::IsFailedQC() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_QC_FAILED) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsFirstMate(void) const
+/*! \fn bool BamAlignment::IsFirstMate() const
     \return \c true if alignment is first mate on paired-end read
 */
-bool BamAlignment::IsFirstMate(void) const {
+bool BamAlignment::IsFirstMate() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_READ_1) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsMapped(void) const
+/*! \fn bool BamAlignment::IsMapped() const
     \return \c true if alignment is mapped
 */
-bool BamAlignment::IsMapped(void) const {
+bool BamAlignment::IsMapped() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_UNMAPPED) == 0 );
 }
 
-/*! \fn bool BamAlignment::IsMateMapped(void) const
+/*! \fn bool BamAlignment::IsMateMapped() const
     \return \c true if alignment's mate is mapped
 */
-bool BamAlignment::IsMateMapped(void) const {
+bool BamAlignment::IsMateMapped() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_MATE_UNMAPPED) == 0 );
 }
 
-/*! \fn bool BamAlignment::IsMateReverseStrand(void) const
+/*! \fn bool BamAlignment::IsMateReverseStrand() const
     \return \c true if alignment's mate mapped to reverse strand
 */
-bool BamAlignment::IsMateReverseStrand(void) const {
+bool BamAlignment::IsMateReverseStrand() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_MATE_REVERSE_STRAND) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsPaired(void) const
+/*! \fn bool BamAlignment::IsPaired() const
     \return \c true if alignment part of paired-end read
 */
-bool BamAlignment::IsPaired(void) const {
+bool BamAlignment::IsPaired() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_PAIRED) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsPrimaryAlignment(void) const
+/*! \fn bool BamAlignment::IsPrimaryAlignment() const
     \return \c true if reported position is primary alignment
 */
-bool BamAlignment::IsPrimaryAlignment(void) const  {
+bool BamAlignment::IsPrimaryAlignment() const  {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_SECONDARY) == 0 );
 }
 
-/*! \fn bool BamAlignment::IsProperPair(void) const
+/*! \fn bool BamAlignment::IsProperPair() const
     \return \c true if alignment is part of read that satisfied paired-end resolution
 */
-bool BamAlignment::IsProperPair(void) const {
+bool BamAlignment::IsProperPair() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_PROPER_PAIR) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsReverseStrand(void) const
+/*! \fn bool BamAlignment::IsReverseStrand() const
     \return \c true if alignment mapped to reverse strand
 */
-bool BamAlignment::IsReverseStrand(void) const {
+bool BamAlignment::IsReverseStrand() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_REVERSE_STRAND) != 0 );
 }
 
-/*! \fn bool BamAlignment::IsSecondMate(void) const
+/*! \fn bool BamAlignment::IsSecondMate() const
     \return \c true if alignment is second mate on read
 */
-bool BamAlignment::IsSecondMate(void) const {
+bool BamAlignment::IsSecondMate() const {
     return ( (AlignmentFlag & Constants::BAM_ALIGNMENT_READ_2) != 0 );
 }
 

--- a/src/api/BamAlignment.h
+++ b/src/api/BamAlignment.h
@@ -33,23 +33,23 @@ class API_EXPORT BamAlignment {
 
     // constructors & destructor
     public:
-        BamAlignment(void);
+        BamAlignment();
         BamAlignment(const BamAlignment& other);
-        ~BamAlignment(void);
+        ~BamAlignment();
 
     // queries against alignment flags
     public:
-        bool IsDuplicate(void) const;         // returns true if this read is a PCR duplicate
-        bool IsFailedQC(void) const;          // returns true if this read failed quality control
-        bool IsFirstMate(void) const;         // returns true if alignment is first mate on read
-        bool IsMapped(void) const;            // returns true if alignment is mapped
-        bool IsMateMapped(void) const;        // returns true if alignment's mate is mapped
-        bool IsMateReverseStrand(void) const; // returns true if alignment's mate mapped to reverse strand
-        bool IsPaired(void) const;            // returns true if alignment part of paired-end read
-        bool IsPrimaryAlignment(void) const;  // returns true if reported position is primary alignment
-        bool IsProperPair(void) const;        // returns true if alignment is part of read that satisfied paired-end resolution
-        bool IsReverseStrand(void) const;     // returns true if alignment mapped to reverse strand
-        bool IsSecondMate(void) const;        // returns true if alignment is second mate on read
+        bool IsDuplicate() const;         // returns true if this read is a PCR duplicate
+        bool IsFailedQC() const;          // returns true if this read failed quality control
+        bool IsFirstMate() const;         // returns true if alignment is first mate on read
+        bool IsMapped() const;            // returns true if alignment is mapped
+        bool IsMateMapped() const;        // returns true if alignment's mate is mapped
+        bool IsMateReverseStrand() const; // returns true if alignment's mate mapped to reverse strand
+        bool IsPaired() const;            // returns true if alignment part of paired-end read
+        bool IsPrimaryAlignment() const;  // returns true if reported position is primary alignment
+        bool IsProperPair() const;        // returns true if alignment is part of read that satisfied paired-end resolution
+        bool IsReverseStrand() const;     // returns true if alignment mapped to reverse strand
+        bool IsSecondMate() const;        // returns true if alignment is second mate on read
 
     // manipulate alignment flags
     public:
@@ -81,7 +81,7 @@ class API_EXPORT BamAlignment {
         template<typename T> bool GetTag(const std::string& tag, std::vector<T>& destination) const;
 
         // retrieves all current tag names
-        std::vector<std::string> GetTagNames(void) const;
+        std::vector<std::string> GetTagNames() const;
 
         // retrieves the SAM/BAM type-code for requested tag name
         bool GetTagType(const std::string& tag, char& type) const;
@@ -98,13 +98,13 @@ class API_EXPORT BamAlignment {
     // additional methods
     public:
         // populates alignment string fields
-        bool BuildCharData(void);
+        bool BuildCharData();
 
         // calculates alignment end position
         int GetEndPosition(bool usePadded = false, bool closedInterval = false) const;
 
         // returns a description of the last error that occurred
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
 
         // retrieves the size, read locations and reference locations of soft-clip operations
         bool GetSoftClips(std::vector<int>& clipSizes,
@@ -158,7 +158,7 @@ class API_EXPORT BamAlignment {
             bool        HasCoreOnly;
 
             // constructor
-            BamAlignmentSupportData(void)
+            BamAlignmentSupportData()
                 : BlockLength(0)
                 , NumCigarOperations(0)
                 , QueryNameLength(0)

--- a/src/api/BamAux.h
+++ b/src/api/BamAux.h
@@ -112,23 +112,23 @@ struct API_EXPORT BamRegion {
     { }
 
     //! Clears region boundaries
-    void clear(void) {
+    void clear() {
         LeftRefID  = -1; LeftPosition  = -1;
         RightRefID = -1; RightPosition = -1;
     }
 
     //! Returns true if region has a left boundary
-    bool isLeftBoundSpecified(void) const {
+    bool isLeftBoundSpecified() const {
         return ( LeftRefID >= 0 && LeftPosition >= 0 );
     }
 
     //! Returns true if region boundaries are not defined
-    bool isNull(void) const {
+    bool isNull() const {
         return ( !isLeftBoundSpecified() && !isRightBoundSpecified() );
     }
 
     //! Returns true if region has a right boundary
-    bool isRightBoundSpecified(void) const {
+    bool isRightBoundSpecified() const {
         return ( RightRefID >= 0 && RightPosition >= 1 );
     }
 };
@@ -240,11 +240,11 @@ API_EXPORT inline void SwapEndian_64p(char* data) {
     SwapEndian_64(value);
 }
 
-/*! \fn bool SystemIsBigEndian(void)
+/*! \fn bool SystemIsBigEndian()
     \brief checks host architecture's byte order
     \return \c true if system uses big-endian ordering
 */
-API_EXPORT inline bool SystemIsBigEndian(void) {
+API_EXPORT inline bool SystemIsBigEndian() {
    const uint16_t one = 0x0001;
    return ((*(char*) &one) == 0 );
 }
@@ -466,12 +466,12 @@ struct RaiiBuffer {
         , NumBytes(n)
     { }
 
-    ~RaiiBuffer(void) {
+    ~RaiiBuffer() {
         delete[] Buffer;
     }
 
     // add'l methods
-    void Clear(void) {
+    void Clear() {
         memset(Buffer, 0, NumBytes);
     }
 };

--- a/src/api/BamConstants.h
+++ b/src/api/BamConstants.h
@@ -154,7 +154,7 @@ template<typename T>
 struct TagTypeHelper {
     static bool CanConvertFrom(const char) { assert(false); return false; }
     static bool CanConvertTo(const char) { assert(false); return false; }
-    static char TypeCode(void) { assert(false); return 0; }
+    static char TypeCode() { assert(false); return 0; }
 };
 
 template<>
@@ -170,7 +170,7 @@ struct TagTypeHelper<uint8_t> {
                  c == Constants::BAM_TAG_TYPE_UINT32 );
     }
 
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_UINT8; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_UINT8; }
 };
 
 template<>
@@ -185,7 +185,7 @@ struct TagTypeHelper<int8_t> {
                  c == Constants::BAM_TAG_TYPE_INT16 ||
                  c == Constants::BAM_TAG_TYPE_INT32 );
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_INT8; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_INT8; }
 };
 
 template<>
@@ -199,7 +199,7 @@ struct TagTypeHelper<uint16_t> {
         return ( c == Constants::BAM_TAG_TYPE_UINT16 ||
                  c == Constants::BAM_TAG_TYPE_UINT32);
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_UINT16; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_UINT16; }
 };
 
 template<>
@@ -213,7 +213,7 @@ struct TagTypeHelper<int16_t> {
         return ( c == Constants::BAM_TAG_TYPE_INT16 ||
                  c == Constants::BAM_TAG_TYPE_INT32);
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_INT16; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_INT16; }
 };
 
 template<>
@@ -227,7 +227,7 @@ struct TagTypeHelper<uint32_t> {
     static bool CanConvertTo(const char c) {
         return ( c == Constants::BAM_TAG_TYPE_UINT32 );
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_UINT32; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_UINT32; }
 };
 
 template<>
@@ -241,7 +241,7 @@ struct TagTypeHelper<int32_t> {
     static bool CanConvertTo(const char c) {
         return ( c == Constants::BAM_TAG_TYPE_INT32 );
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_INT32; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_INT32; }
 };
 
 template<>
@@ -259,7 +259,7 @@ struct TagTypeHelper<float> {
     static bool CanConvertTo(const char c) {
         return ( c == Constants::BAM_TAG_TYPE_FLOAT );
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_FLOAT; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_FLOAT; }
 };
 
 template<>
@@ -272,7 +272,7 @@ struct TagTypeHelper<std::string> {
         return ( c == Constants::BAM_TAG_TYPE_HEX ||
                  c == Constants::BAM_TAG_TYPE_STRING );
     }
-    static char TypeCode(void) { return Constants::BAM_TAG_TYPE_STRING; }
+    static char TypeCode() { return Constants::BAM_TAG_TYPE_STRING; }
 };
 
 //! \endcond

--- a/src/api/BamIndex.h
+++ b/src/api/BamIndex.h
@@ -44,15 +44,15 @@ class API_EXPORT BamIndex {
     // ctor & dtor
     public:
         BamIndex(Internal::BamReaderPrivate* reader) : m_reader(reader) { }
-        virtual ~BamIndex(void) { }
+        virtual ~BamIndex() { }
 
     // index interface
     public:
         // builds index from associated BAM file & writes out to index file
-        virtual bool Create(void) =0;
+        virtual bool Create() =0;
 
         // returns a human-readable description of the last error encountered
-        std::string GetErrorString(void) { return m_errorString; }
+        std::string GetErrorString() { return m_errorString; }
 
         // returns whether reference has alignments or no
         virtual bool HasAlignments(const int& referenceID) const =0;
@@ -67,7 +67,7 @@ class API_EXPORT BamIndex {
         virtual bool Load(const std::string& filename) =0;
 
         // returns the 'type' enum for derived index format
-        virtual BamIndex::IndexType Type(void) const =0;
+        virtual BamIndex::IndexType Type() const =0;
 
     //! \cond
 

--- a/src/api/BamMultiReader.cpp
+++ b/src/api/BamMultiReader.cpp
@@ -38,29 +38,29 @@ using namespace BamTools;
     \brief Merge strategy when BAM files are sorted by read name ('queryname')
 */
 
-/*! \fn BamMultiReader::BamMultiReader(void)
+/*! \fn BamMultiReader::BamMultiReader()
     \brief constructor
 */
-BamMultiReader::BamMultiReader(void)
+BamMultiReader::BamMultiReader()
     : d(new Internal::BamMultiReaderPrivate)
 { }
 
-/*! \fn BamMultiReader::~BamMultiReader(void)
+/*! \fn BamMultiReader::~BamMultiReader()
     \brief destructor
 */
-BamMultiReader::~BamMultiReader(void) {
+BamMultiReader::~BamMultiReader() {
     delete d;
     d = 0;
 }
 
-/*! \fn void BamMultiReader::Close(void)
+/*! \fn void BamMultiReader::Close()
     \brief Closes all open BAM files.
 
     Also clears out all header and reference data.
 
     \sa CloseFile(), IsOpen(), Open(), BamReader::Close()
 */
-bool BamMultiReader::Close(void) {
+bool BamMultiReader::Close() {
     return d->Close();
 }
 
@@ -88,7 +88,7 @@ bool BamMultiReader::CreateIndexes(const BamIndex::IndexType& type) {
     return d->CreateIndexes(type);
 }
 
-/*! \fn const std::vector<std::string> BamMultiReader::Filenames(void) const
+/*! \fn const std::vector<std::string> BamMultiReader::Filenames() const
     \brief Returns list of filenames for all open BAM files.
 
     Retrieved filenames will contain whatever was passed via Open().
@@ -98,11 +98,11 @@ bool BamMultiReader::CreateIndexes(const BamIndex::IndexType& type) {
     \returns names of open BAM files. If no files are open, returns an empty vector.
     \sa IsOpen(), BamReader::GetFilename()
 */
-const std::vector<std::string> BamMultiReader::Filenames(void) const {
+const std::vector<std::string> BamMultiReader::Filenames() const {
     return d->Filenames();
 }
 
-/*! \fn std::string BamMultiReader::GetErrorString(void) const
+/*! \fn std::string BamMultiReader::GetErrorString() const
     \brief Returns a human-readable description of the last error that occurred
 
     This method allows elimination of STDERR pollution. Developers of client code
@@ -110,11 +110,11 @@ const std::vector<std::string> BamMultiReader::Filenames(void) const {
 
     \return error description
 */
-std::string BamMultiReader::GetErrorString(void) const {
+std::string BamMultiReader::GetErrorString() const {
     return d->GetErrorString();
 }
 
-/*! \fn SamHeader BamMultiReader::GetHeader(void) const
+/*! \fn SamHeader BamMultiReader::GetHeader() const
     \brief Returns unified SAM-format header for all files
 
     \note Modifying the retrieved text does NOT affect the current
@@ -125,11 +125,11 @@ std::string BamMultiReader::GetErrorString(void) const {
     \returns header data wrapped in SamHeader object
     \sa GetHeaderText(), BamReader::GetHeader()
 */
-SamHeader BamMultiReader::GetHeader(void) const {
+SamHeader BamMultiReader::GetHeader() const {
     return d->GetHeader();
 }
 
-/*! \fn std::string BamMultiReader::GetHeaderText(void) const
+/*! \fn std::string BamMultiReader::GetHeaderText() const
     \brief Returns unified SAM-format header text for all files
 
     \note Modifying the retrieved text does NOT affect the current
@@ -140,17 +140,17 @@ SamHeader BamMultiReader::GetHeader(void) const {
     \returns SAM-formatted header text
     \sa GetHeader(), BamReader::GetHeaderText()
 */
-std::string BamMultiReader::GetHeaderText(void) const {
+std::string BamMultiReader::GetHeaderText() const {
     return d->GetHeaderText();
 }
 
-/*! \fn BamMultiReader::MergeOrder BamMultiReader::GetMergeOrder(void) const
+/*! \fn BamMultiReader::MergeOrder BamMultiReader::GetMergeOrder() const
     \brief Returns curent merge order strategy.
 
     \returns current merge order enum value
     \sa BamMultiReader::MergeOrder, SetExplicitMergeOrder()
 */
-BamMultiReader::MergeOrder BamMultiReader::GetMergeOrder(void) const {
+BamMultiReader::MergeOrder BamMultiReader::GetMergeOrder() const {
     return d->GetMergeOrder();
 }
 
@@ -188,19 +188,19 @@ bool BamMultiReader::GetNextAlignmentCore(BamAlignment& nextAlignment) {
     return d->GetNextAlignmentCore(nextAlignment);
 }
 
-/*! \fn int BamMultiReader::GetReferenceCount(void) const
+/*! \fn int BamMultiReader::GetReferenceCount() const
     \brief Returns number of reference sequences.
     \sa BamReader::GetReferenceCount()
 */
-int BamMultiReader::GetReferenceCount(void) const {
+int BamMultiReader::GetReferenceCount() const {
     return d->GetReferenceCount();
 }
 
-/*! \fn const RefVector& BamMultiReader::GetReferenceData(void) const
+/*! \fn const RefVector& BamMultiReader::GetReferenceData() const
     \brief Returns all reference sequence entries.
     \sa RefData, BamReader::GetReferenceData()
 */
-const BamTools::RefVector BamMultiReader::GetReferenceData(void) const {
+const BamTools::RefVector BamMultiReader::GetReferenceData() const {
     return d->GetReferenceData();
 }
 
@@ -216,18 +216,18 @@ int BamMultiReader::GetReferenceID(const std::string& refName) const {
     return d->GetReferenceID(refName);
 }
 
-/*! \fn bool BamMultiReader::HasIndexes(void) const
+/*! \fn bool BamMultiReader::HasIndexes() const
     \brief Returns \c true if all BAM files have index data available.
     \sa BamReader::HasIndex()
 */
-bool BamMultiReader::HasIndexes(void) const {
+bool BamMultiReader::HasIndexes() const {
     return d->HasIndexes();
 }
 
-/*! \fn bool BamMultiReader::HasOpenReaders(void) const
+/*! \fn bool BamMultiReader::HasOpenReaders() const
     \brief Returns \c true if there are any open BAM files.
 */
-bool BamMultiReader::HasOpenReaders(void) const {
+bool BamMultiReader::HasOpenReaders() const {
     return d->HasOpenReaders();
 }
 
@@ -332,7 +332,7 @@ bool BamMultiReader::OpenIndexes(const std::vector<std::string>& indexFilenames)
     return d->OpenIndexes(indexFilenames);
 }
 
-/*! \fn bool BamMultiReader::Rewind(void)
+/*! \fn bool BamMultiReader::Rewind()
     \brief Returns the internal file pointers to the beginning of alignment records.
 
     Useful for performing multiple sequential passes through BAM files.
@@ -341,7 +341,7 @@ bool BamMultiReader::OpenIndexes(const std::vector<std::string>& indexFilenames)
     \returns \c true if rewind operation was successful
     \sa Jump(), SetRegion(), BamReader::Rewind()
 */
-bool BamMultiReader::Rewind(void) {
+bool BamMultiReader::Rewind() {
     return d->Rewind();
 }
 

--- a/src/api/BamMultiReader.h
+++ b/src/api/BamMultiReader.h
@@ -35,8 +35,8 @@ class API_EXPORT BamMultiReader {
 
     // constructor / destructor
     public:
-        BamMultiReader(void);
-        ~BamMultiReader(void);
+        BamMultiReader();
+        ~BamMultiReader();
 
     // public interface
     public:
@@ -46,15 +46,15 @@ class API_EXPORT BamMultiReader {
         // ----------------------
 
         // closes all open BAM files
-        bool Close(void);
+        bool Close();
         // close only the requested BAM file
         bool CloseFile(const std::string& filename);
         // returns list of filenames for all open BAM files
-        const std::vector<std::string> Filenames(void) const;
+        const std::vector<std::string> Filenames() const;
         // returns curent merge order strategy
-        BamMultiReader::MergeOrder GetMergeOrder(void) const;
+        BamMultiReader::MergeOrder GetMergeOrder() const;
         // returns true if multireader has any open BAM files
-        bool HasOpenReaders(void) const;
+        bool HasOpenReaders() const;
         // performs random-access jump within current BAM files
         bool Jump(int refID, int position = 0);
         // opens BAM files
@@ -62,7 +62,7 @@ class API_EXPORT BamMultiReader {
         // opens a single BAM file, adding to any other current BAM files
         bool OpenFile(const std::string& filename);
         // returns file pointers to beginning of alignments
-        bool Rewind(void);
+        bool Rewind();
         // sets an explicit merge order, regardless of the BAM files' SO header tag
         bool SetExplicitMergeOrder(BamMultiReader::MergeOrder order);
         // sets the target region of interest
@@ -87,13 +87,13 @@ class API_EXPORT BamMultiReader {
         // ----------------------
 
         // returns unified SAM header for all files
-        SamHeader GetHeader(void) const;
+        SamHeader GetHeader() const;
         // returns unified SAM header text for all files
-        std::string GetHeaderText(void) const;
+        std::string GetHeaderText() const;
         // returns number of reference sequences
-        int GetReferenceCount(void) const;
+        int GetReferenceCount() const;
         // returns all reference sequence entries.
-        const BamTools::RefVector GetReferenceData(void) const;
+        const BamTools::RefVector GetReferenceData() const;
         // returns the ID of the reference with this name.
         int GetReferenceID(const std::string& refName) const;
 
@@ -104,7 +104,7 @@ class API_EXPORT BamMultiReader {
         // creates index files for current BAM files
         bool CreateIndexes(const BamIndex::IndexType& type = BamIndex::STANDARD);
         // returns true if all BAM files have index data available
-        bool HasIndexes(void) const;
+        bool HasIndexes() const;
         // looks for index files that match current BAM files
         bool LocateIndexes(const BamIndex::IndexType& preferredType = BamIndex::STANDARD);
         // opens index files for current BAM files.
@@ -115,7 +115,7 @@ class API_EXPORT BamMultiReader {
         // ----------------------
 
         // returns a human-readable description of the last error that occurred
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
 
     // private implementation
     private:

--- a/src/api/BamReader.cpp
+++ b/src/api/BamReader.cpp
@@ -22,22 +22,22 @@ using namespace BamTools::Internal;
     \brief Provides read access to BAM files.
 */
 
-/*! \fn BamReader::BamReader(void)
+/*! \fn BamReader::BamReader()
     \brief constructor
 */
-BamReader::BamReader(void)
+BamReader::BamReader()
     : d(new BamReaderPrivate(this))
 { }
 
-/*! \fn BamReader::~BamReader(void)
+/*! \fn BamReader::~BamReader()
     \brief destructor
 */
-BamReader::~BamReader(void) {
+BamReader::~BamReader() {
     delete d;
     d = 0;
 }
 
-/*! \fn bool BamReader::Close(void)
+/*! \fn bool BamReader::Close()
     \brief Closes the current BAM file.
 
     Also clears out all header and reference data.
@@ -45,7 +45,7 @@ BamReader::~BamReader(void) {
     \return \c true if file closed OK
     \sa IsOpen(), Open()
 */
-bool BamReader::Close(void) {
+bool BamReader::Close() {
     return d->Close();
 }
 
@@ -60,7 +60,7 @@ bool BamReader::CreateIndex(const BamIndex::IndexType& type) {
     return d->CreateIndex(type);
 }
 
-/*! \fn const SamHeader& BamReader::GetConstSamHeader(void) const
+/*! \fn const SamHeader& BamReader::GetConstSamHeader() const
     \brief Returns const reference to SAM header data.
 
     Allows for read-only queries of SAM header data.
@@ -72,11 +72,11 @@ bool BamReader::CreateIndex(const BamIndex::IndexType& type) {
     \returns const reference to header data object
     \sa GetHeader(), GetHeaderText()
 */
-const SamHeader& BamReader::GetConstSamHeader(void) const {
+const SamHeader& BamReader::GetConstSamHeader() const {
     return d->GetConstSamHeader();
 }
 
-/*! \fn std::string BamReader::GetErrorString(void) const
+/*! \fn std::string BamReader::GetErrorString() const
     \brief Returns a human-readable description of the last error that occurred
 
     This method allows elimination of STDERR pollution. Developers of client code
@@ -84,11 +84,11 @@ const SamHeader& BamReader::GetConstSamHeader(void) const {
 
     \return error description
 */
-std::string BamReader::GetErrorString(void) const {
+std::string BamReader::GetErrorString() const {
     return d->GetErrorString();
 }
 
-/*! \fn const std::string BamReader::GetFilename(void) const
+/*! \fn const std::string BamReader::GetFilename() const
     \brief Returns name of current BAM file.
 
     Retrieved filename will contain whatever was passed via Open().
@@ -98,11 +98,11 @@ std::string BamReader::GetErrorString(void) const {
     \returns name of open BAM file. If no file is open, returns an empty string.
     \sa IsOpen()
 */
-const std::string BamReader::GetFilename(void) const {
+const std::string BamReader::GetFilename() const {
     return d->Filename();
 }
 
-/*! \fn SamHeader BamReader::GetHeader(void) const
+/*! \fn SamHeader BamReader::GetHeader() const
     \brief Returns SAM header data.
 
     Header data is wrapped in a SamHeader object that can be conveniently queried and/or modified.
@@ -116,11 +116,11 @@ const std::string BamReader::GetFilename(void) const {
     \returns header data object
     \sa GetConstSamHeader(), GetHeaderText()
 */
-SamHeader BamReader::GetHeader(void) const {
+SamHeader BamReader::GetHeader() const {
     return d->GetSamHeader();
 }
 
-/*! \fn std::string BamReader::GetHeaderText(void) const
+/*! \fn std::string BamReader::GetHeaderText() const
     \brief Returns SAM header data, as SAM-formatted text.
 
     \note Modifying the retrieved text does NOT affect the current
@@ -131,7 +131,7 @@ SamHeader BamReader::GetHeader(void) const {
     \returns SAM-formatted header text
     \sa GetHeader()
 */
-std::string BamReader::GetHeaderText(void) const {
+std::string BamReader::GetHeaderText() const {
     return d->GetHeaderText();
 }
 
@@ -181,18 +181,18 @@ bool BamReader::GetNextAlignmentCore(BamAlignment& alignment) {
     return d->GetNextAlignmentCore(alignment);
 }
 
-/*! \fn int BamReader::GetReferenceCount(void) const
+/*! \fn int BamReader::GetReferenceCount() const
     \brief Returns number of reference sequences.
 */
-int BamReader::GetReferenceCount(void) const {
+int BamReader::GetReferenceCount() const {
     return d->GetReferenceCount();
 }
 
-/*! \fn const RefVector& BamReader::GetReferenceData(void) const
+/*! \fn const RefVector& BamReader::GetReferenceData() const
     \brief Returns all reference sequence entries.
     \sa RefData
 */
-const RefVector& BamReader::GetReferenceData(void) const {
+const RefVector& BamReader::GetReferenceData() const {
     return d->GetReferenceData();
 }
 
@@ -207,17 +207,17 @@ int BamReader::GetReferenceID(const std::string& refName) const {
     return d->GetReferenceID(refName);
 }
 
-/*! \fn bool BamReader::HasIndex(void) const
+/*! \fn bool BamReader::HasIndex() const
     \brief Returns \c true if index data is available.
 */
-bool BamReader::HasIndex(void) const {
+bool BamReader::HasIndex() const {
     return d->HasIndex();
 }
 
-/*! \fn bool BamReader::IsOpen(void) const
+/*! \fn bool BamReader::IsOpen() const
     \brief Returns \c true if a BAM file is open for reading.
 */
-bool BamReader::IsOpen(void) const {
+bool BamReader::IsOpen() const {
     return d->IsOpen();
 }
 
@@ -287,7 +287,7 @@ bool BamReader::OpenIndex(const std::string& indexFilename) {
     return d->OpenIndex(indexFilename);
 }
 
-/*! \fn bool BamReader::Rewind(void)
+/*! \fn bool BamReader::Rewind()
     \brief Returns the internal file pointer to the first alignment record.
 
     Useful for performing multiple sequential passes through a BAM file.
@@ -299,7 +299,7 @@ bool BamReader::OpenIndex(const std::string& indexFilename) {
     \returns \c true if rewind operation was successful
     \sa Jump(), SetRegion()
 */
-bool BamReader::Rewind(void) {
+bool BamReader::Rewind() {
     return d->Rewind();
 }
 

--- a/src/api/BamReader.h
+++ b/src/api/BamReader.h
@@ -26,8 +26,8 @@ class API_EXPORT BamReader {
 
     // constructor / destructor
     public:
-        BamReader(void);
-        ~BamReader(void);
+        BamReader();
+        ~BamReader();
 
     // public interface
     public:
@@ -37,17 +37,17 @@ class API_EXPORT BamReader {
         // ----------------------
 
         // closes the current BAM file
-        bool Close(void);
+        bool Close();
         // returns filename of current BAM file
-        const std::string GetFilename(void) const;
+        const std::string GetFilename() const;
         // returns true if a BAM file is open for reading
-        bool IsOpen(void) const;
+        bool IsOpen() const;
         // performs random-access jump within BAM file
         bool Jump(int refID, int position = 0);
         // opens a BAM file
         bool Open(const std::string& filename);
         // returns internal file pointer to beginning of alignment data
-        bool Rewind(void);
+        bool Rewind();
         // sets the target region of interest
         bool SetRegion(const BamRegion& region);
         // sets the target region of interest
@@ -70,20 +70,20 @@ class API_EXPORT BamReader {
         // ----------------------
 
         // returns a read-only reference to SAM header data
-        const SamHeader& GetConstSamHeader(void) const;
+        const SamHeader& GetConstSamHeader() const;
         // returns an editable copy of SAM header data
-        SamHeader GetHeader(void) const;
+        SamHeader GetHeader() const;
         // returns SAM header data, as SAM-formatted text
-        std::string GetHeaderText(void) const;
+        std::string GetHeaderText() const;
 
         // ----------------------
         // access reference data
         // ----------------------
 
         // returns the number of reference sequences
-        int GetReferenceCount(void) const;
+        int GetReferenceCount() const;
         // returns all reference sequence entries
-        const RefVector& GetReferenceData(void) const;
+        const RefVector& GetReferenceData() const;
         // returns the ID of the reference with this name
         int GetReferenceID(const std::string& refName) const;
 
@@ -94,7 +94,7 @@ class API_EXPORT BamReader {
         // creates an index file for current BAM file, using the requested index type
         bool CreateIndex(const BamIndex::IndexType& type = BamIndex::STANDARD);
         // returns true if index data is available
-        bool HasIndex(void) const;
+        bool HasIndex() const;
         // looks in BAM file's directory for a matching index file
         bool LocateIndex(const BamIndex::IndexType& preferredType = BamIndex::STANDARD);
         // opens a BAM index file
@@ -107,7 +107,7 @@ class API_EXPORT BamReader {
         // ----------------------
 
         // returns a human-readable description of the last error that occurred
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
 
     // private implementation
     private:

--- a/src/api/BamWriter.cpp
+++ b/src/api/BamWriter.cpp
@@ -31,30 +31,30 @@ using namespace BamTools::Internal;
     the data.
 */
 
-/*! \fn BamWriter::BamWriter(void)
+/*! \fn BamWriter::BamWriter()
     \brief constructor
 */
-BamWriter::BamWriter(void)
+BamWriter::BamWriter()
     : d(new BamWriterPrivate)
 { }
 
-/*! \fn BamWriter::~BamWriter(void)
+/*! \fn BamWriter::~BamWriter()
     \brief destructor
 */
-BamWriter::~BamWriter(void) {
+BamWriter::~BamWriter() {
     delete d;
     d = 0;
 }
 
-/*! \fn BamWriter::Close(void)
+/*! \fn BamWriter::Close()
     \brief Closes the current BAM file.
     \sa Open()
 */
-void BamWriter::Close(void) {
+void BamWriter::Close() {
     d->Close();
 }
 
-/*! \fn std::string BamWriter::GetErrorString(void) const
+/*! \fn std::string BamWriter::GetErrorString() const
     \brief Returns a human-readable description of the last error that occurred
 
     This method allows elimination of STDERR pollution. Developers of client code
@@ -62,15 +62,15 @@ void BamWriter::Close(void) {
 
     \return error description
 */
-std::string BamWriter::GetErrorString(void) const {
+std::string BamWriter::GetErrorString() const {
     return d->GetErrorString();
 }
 
-/*! \fn bool BamWriter::IsOpen(void) const
+/*! \fn bool BamWriter::IsOpen() const
     \brief Returns \c true if BAM file is open for writing.
     \sa Open()
 */
-bool BamWriter::IsOpen(void) const {
+bool BamWriter::IsOpen() const {
     return d->IsOpen();
 }
 

--- a/src/api/BamWriter.h
+++ b/src/api/BamWriter.h
@@ -35,17 +35,17 @@ class API_EXPORT BamWriter {
 
     // ctor & dtor
     public:
-        BamWriter(void);
-        ~BamWriter(void);
+        BamWriter();
+        ~BamWriter();
 
     // public interface
     public:
         //  closes the current BAM file
-        void Close(void);
+        void Close();
         // returns a human-readable description of the last error that occurred
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
         // returns true if BAM file is open for writing
-        bool IsOpen(void) const;
+        bool IsOpen() const;
         // opens a BAM file for writing
         bool Open(const std::string& filename,
                   const std::string& samHeaderText,

--- a/src/api/IBamIODevice.h
+++ b/src/api/IBamIODevice.h
@@ -35,7 +35,7 @@ class API_EXPORT IBamIODevice {
 
     // ctor & dtor
     public:
-        virtual ~IBamIODevice(void) { }
+        virtual ~IBamIODevice() { }
 
     // IBamIODevice interface
     public:
@@ -43,22 +43,22 @@ class API_EXPORT IBamIODevice {
         // TODO: add seek(pos, *from*)
 
         // pure virtuals
-        virtual void Close(void) =0;
-        virtual bool IsRandomAccess(void) const =0;
+        virtual void Close() =0;
+        virtual bool IsRandomAccess() const =0;
         virtual bool Open(const OpenMode mode) =0;
         virtual int64_t Read(char* data, const unsigned int numBytes) =0;
         virtual bool Seek(const int64_t& position, const int origin = SEEK_SET) =0;
-        virtual int64_t Tell(void) const =0;
+        virtual int64_t Tell() const =0;
         virtual int64_t Write(const char* data, const unsigned int numBytes) =0;
 
         // default implementation provided
-        virtual std::string GetErrorString(void);
-        virtual bool IsOpen(void) const;
-        virtual OpenMode Mode(void) const;
+        virtual std::string GetErrorString();
+        virtual bool IsOpen() const;
+        virtual OpenMode Mode() const;
 
     // internal methods
     protected:
-        IBamIODevice(void); // hidden ctor
+        IBamIODevice(); // hidden ctor
         void SetErrorString(const std::string& where, const std::string& what);
 
     // data members
@@ -68,22 +68,22 @@ class API_EXPORT IBamIODevice {
 };
 
 inline
-IBamIODevice::IBamIODevice(void)
+IBamIODevice::IBamIODevice()
     : m_mode(IBamIODevice::NotOpen)
 { }
 
 inline
-std::string IBamIODevice::GetErrorString(void) {
+std::string IBamIODevice::GetErrorString() {
     return m_errorString;
 }
 
 inline
-bool IBamIODevice::IsOpen(void) const {
+bool IBamIODevice::IsOpen() const {
     return ( m_mode != IBamIODevice::NotOpen );
 }
 
 inline
-IBamIODevice::OpenMode IBamIODevice::Mode(void) const {
+IBamIODevice::OpenMode IBamIODevice::Mode() const {
     return m_mode;
 }
 

--- a/src/api/SamHeader.cpp
+++ b/src/api/SamHeader.cpp
@@ -76,15 +76,15 @@ SamHeader::SamHeader(const SamHeader& other)
     , m_errorString(other.GetErrorString())
 { }
 
-/*! \fn SamHeader::~SamHeader(void)
+/*! \fn SamHeader::~SamHeader()
     \brief destructor
 */
-SamHeader::~SamHeader(void) { }
+SamHeader::~SamHeader() { }
 
-/*! \fn void SamHeader::Clear(void)
+/*! \fn void SamHeader::Clear()
     \brief Clears all header contents.
 */
-void SamHeader::Clear(void) {
+void SamHeader::Clear() {
 
     // clear SAM header components
     Version.clear();
@@ -100,7 +100,7 @@ void SamHeader::Clear(void) {
     m_errorString.clear();
 }
 
-/*! \fn std::string SamHeader::GetErrorString(void) const
+/*! \fn std::string SamHeader::GetErrorString() const
     \brief Returns a human-readable description of the last error that occurred
 
     This method allows elimination of STDERR pollution. Developers of client code
@@ -108,63 +108,63 @@ void SamHeader::Clear(void) {
 
     \return error description
 */
-std::string SamHeader::GetErrorString(void) const {
+std::string SamHeader::GetErrorString() const {
     return m_errorString;
 }
 
-/*! \fn bool SamHeader::HasError(void) const
+/*! \fn bool SamHeader::HasError() const
     \brief Returns \c true if header encountered an error
 */
-bool SamHeader::HasError(void) const {
+bool SamHeader::HasError() const {
     return (!m_errorString.empty());
 }
 
-/*! \fn bool SamHeader::HasVersion(void) const
+/*! \fn bool SamHeader::HasVersion() const
     \brief Returns \c true if header contains \@HD ID:\<Version\>
 */
-bool SamHeader::HasVersion(void) const {
+bool SamHeader::HasVersion() const {
     return (!Version.empty());
 }
 
-/*! \fn bool SamHeader::HasSortOrder(void) const
+/*! \fn bool SamHeader::HasSortOrder() const
     \brief Returns \c true if header contains \@HD SO:\<SortOrder\>
 */
-bool SamHeader::HasSortOrder(void) const {
+bool SamHeader::HasSortOrder() const {
     return (!SortOrder.empty());
 }
 
-/*! \fn bool SamHeader::HasGroupOrder(void) const
+/*! \fn bool SamHeader::HasGroupOrder() const
     \brief Returns \c true if header contains \@HD GO:\<GroupOrder\>
 */
-bool SamHeader::HasGroupOrder(void) const {
+bool SamHeader::HasGroupOrder() const {
     return (!GroupOrder.empty());
 }
 
-/*! \fn bool SamHeader::HasSequences(void) const
+/*! \fn bool SamHeader::HasSequences() const
     \brief Returns \c true if header contains any \@SQ entries
 */
-bool SamHeader::HasSequences(void) const {
+bool SamHeader::HasSequences() const {
     return (!Sequences.IsEmpty());
 }
 
-/*! \fn bool SamHeader::HasReadGroups(void) const
+/*! \fn bool SamHeader::HasReadGroups() const
     \brief Returns \c true if header contains any \@RG entries
 */
-bool SamHeader::HasReadGroups(void) const {
+bool SamHeader::HasReadGroups() const {
     return (!ReadGroups.IsEmpty());
 }
 
-/*! \fn bool SamHeader::HasPrograms(void) const
+/*! \fn bool SamHeader::HasPrograms() const
     \brief Returns \c true if header contains any \@PG entries
 */
-bool SamHeader::HasPrograms(void) const {
+bool SamHeader::HasPrograms() const {
     return (!Programs.IsEmpty());
 }
 
-/*! \fn bool SamHeader::HasComments(void) const
+/*! \fn bool SamHeader::HasComments() const
     \brief Returns \c true if header contains any \@CO entries
 */
-bool SamHeader::HasComments(void) const {
+bool SamHeader::HasComments() const {
     return (!Comments.empty());
 }
 
@@ -224,14 +224,14 @@ void SamHeader::SetHeaderText(const std::string& headerText) {
     }
 }
 
-/*! \fn std::string SamHeader::ToString(void) const
+/*! \fn std::string SamHeader::ToString() const
     \brief Converts data fields to SAM-formatted text.
 
     Applies any local modifications made since creating this object or calling SetHeaderText().
 
     \return SAM-formatted header text
 */
-std::string SamHeader::ToString(void) const {
+std::string SamHeader::ToString() const {
     SamFormatPrinter printer(*this);
     return printer.ToString();
 }

--- a/src/api/SamHeader.h
+++ b/src/api/SamHeader.h
@@ -26,24 +26,24 @@ struct API_EXPORT SamHeader {
     // ctor & dtor
     SamHeader(const std::string& headerText = "");
     SamHeader(const SamHeader& other);
-    ~SamHeader(void);
+    ~SamHeader();
 
     // query/modify entire SamHeader
-    void Clear(void);                                   // clears all header contents
-    std::string GetErrorString(void) const;
-    bool HasError(void) const;
+    void Clear();                                   // clears all header contents
+    std::string GetErrorString() const;
+    bool HasError() const;
     bool IsValid(bool verbose = false) const;           // returns true if SAM header is well-formed
     void SetHeaderText(const std::string& headerText);  // replaces data fields with contents of SAM-formatted text
-    std::string ToString(void) const;                   // returns the printable, SAM-formatted header text
+    std::string ToString() const;                   // returns the printable, SAM-formatted header text
 
     // convenience query methods
-    bool HasVersion(void) const;     // returns true if header contains format version entry
-    bool HasSortOrder(void) const;   // returns true if header contains sort order entry
-    bool HasGroupOrder(void) const;  // returns true if header contains group order entry
-    bool HasSequences(void) const;   // returns true if header contains any sequence entries
-    bool HasReadGroups(void) const;  // returns true if header contains any read group entries
-    bool HasPrograms(void) const;    // returns true if header contains any program record entries
-    bool HasComments(void) const;    // returns true if header contains comments
+    bool HasVersion() const;     // returns true if header contains format version entry
+    bool HasSortOrder() const;   // returns true if header contains sort order entry
+    bool HasGroupOrder() const;  // returns true if header contains group order entry
+    bool HasSequences() const;   // returns true if header contains any sequence entries
+    bool HasReadGroups() const;  // returns true if header contains any read group entries
+    bool HasPrograms() const;    // returns true if header contains any program record entries
+    bool HasComments() const;    // returns true if header contains comments
 
     // --------------
     // data members

--- a/src/api/SamProgram.cpp
+++ b/src/api/SamProgram.cpp
@@ -39,10 +39,10 @@ using namespace BamTools;
     Holds ID of the "next" program record in a SamProgramChain
 */
 
-/*! \fn SamProgram::SamProgram(void)
+/*! \fn SamProgram::SamProgram()
     \brief default constructor
 */
-SamProgram::SamProgram(void)
+SamProgram::SamProgram()
     : CommandLine("")
     , ID("")
     , Name("")
@@ -78,15 +78,15 @@ SamProgram::SamProgram(const SamProgram& other)
     , NextProgramID(other.NextProgramID)
 { }
 
-/*! \fn SamProgram::~SamProgram(void)
+/*! \fn SamProgram::~SamProgram()
     \brief destructor
 */
-SamProgram::~SamProgram(void) { }
+SamProgram::~SamProgram() { }
 
-/*! \fn void SamProgram::Clear(void)
+/*! \fn void SamProgram::Clear()
     \brief Clears all data fields.
 */
-void SamProgram::Clear(void) {
+void SamProgram::Clear() {
     CommandLine.clear();
     ID.clear();
     Name.clear();
@@ -95,45 +95,45 @@ void SamProgram::Clear(void) {
     NextProgramID.clear();
 }
 
-/*! \fn bool SamProgram::HasCommandLine(void) const
+/*! \fn bool SamProgram::HasCommandLine() const
     \brief Returns \c true if program record contains \@PG: CL:\<CommandLine\>
 */
-bool SamProgram::HasCommandLine(void) const {
+bool SamProgram::HasCommandLine() const {
     return (!CommandLine.empty());
 }
 
-/*! \fn bool SamProgram::HasID(void) const
+/*! \fn bool SamProgram::HasID() const
     \brief Returns \c true if program record contains \@PG: ID:\<ID\>
 */
-bool SamProgram::HasID(void) const {
+bool SamProgram::HasID() const {
     return (!ID.empty());
 }
 
-/*! \fn bool SamProgram::HasName(void) const
+/*! \fn bool SamProgram::HasName() const
     \brief Returns \c true if program record contains \@PG: PN:\<Name\>
 */
-bool SamProgram::HasName(void) const {
+bool SamProgram::HasName() const {
     return (!Name.empty());
 }
 
-/*! \fn bool SamProgram::HasNextProgramID(void) const
+/*! \fn bool SamProgram::HasNextProgramID() const
     \internal
     \return true if program has a "next" record in a SamProgramChain
 */
-bool SamProgram::HasNextProgramID(void) const {
+bool SamProgram::HasNextProgramID() const {
     return (!NextProgramID.empty());
 }
 
-/*! \fn bool SamProgram::HasPreviousProgramID(void) const
+/*! \fn bool SamProgram::HasPreviousProgramID() const
     \brief Returns \c true if program record contains \@PG: PP:\<PreviousProgramID\>
 */
-bool SamProgram::HasPreviousProgramID(void) const {
+bool SamProgram::HasPreviousProgramID() const {
     return (!PreviousProgramID.empty());
 }
 
-/*! \fn bool SamProgram::HasVersion(void) const
+/*! \fn bool SamProgram::HasVersion() const
     \brief Returns \c true if program record contains \@PG: VN:\<Version\>
 */
-bool SamProgram::HasVersion(void) const {
+bool SamProgram::HasVersion() const {
     return (!Version.empty());
 }

--- a/src/api/SamProgram.h
+++ b/src/api/SamProgram.h
@@ -21,20 +21,20 @@ class SamProgramChain;
 struct API_EXPORT SamProgram {
 
     // ctor & dtor
-    SamProgram(void);
+    SamProgram();
     SamProgram(const std::string& id);
     SamProgram(const SamProgram& other);
-    ~SamProgram(void);
+    ~SamProgram();
 
     // query/modify entire program record
-    void Clear(void);                      // clears all data fields
+    void Clear();                      // clears all data fields
 
     // convenience query methods
-    bool HasCommandLine(void) const;       // returns true if program record has a command line entry
-    bool HasID(void) const;                // returns true if program record has an ID
-    bool HasName(void) const;              // returns true if program record has a name
-    bool HasPreviousProgramID(void) const; // returns true if program record has a 'previous program ID'
-    bool HasVersion(void) const;           // returns true if program record has a version
+    bool HasCommandLine() const;       // returns true if program record has a command line entry
+    bool HasID() const;                // returns true if program record has an ID
+    bool HasName() const;              // returns true if program record has a name
+    bool HasPreviousProgramID() const; // returns true if program record has a 'previous program ID'
+    bool HasVersion() const;           // returns true if program record has a version
 
     // data members
     std::string CommandLine;               // CL:<CommandLine>
@@ -46,7 +46,7 @@ struct API_EXPORT SamProgram {
 
     // internal (non-standard) methods & fields
     private:
-        bool HasNextProgramID(void) const;
+        bool HasNextProgramID() const;
         std::string NextProgramID;
         friend class BamTools::SamProgramChain;
 };

--- a/src/api/SamProgramChain.cpp
+++ b/src/api/SamProgramChain.cpp
@@ -25,10 +25,10 @@ using namespace BamTools;
     Instead use First()/Last() to access oldest/newest records, respectively.
 */
 
-/*! \fn SamProgramChain::SamProgramChain(void)
+/*! \fn SamProgramChain::SamProgramChain()
     \brief constructor
 */
-SamProgramChain::SamProgramChain(void) { }
+SamProgramChain::SamProgramChain() { }
 
 /*! \fn SamProgramChain::SamProgramChain(const SamProgramChain& other)
     \brief copy constructor
@@ -37,10 +37,10 @@ SamProgramChain::SamProgramChain(const SamProgramChain& other)
     : m_data(other.m_data)
 { }
 
-/*! \fn SamProgramChain::~SamProgramChain(void)
+/*! \fn SamProgramChain::~SamProgramChain()
     \brief destructor
 */
-SamProgramChain::~SamProgramChain(void) { }
+SamProgramChain::~SamProgramChain() { }
 
 /*! \fn void SamProgramChain::Add(SamProgram& program)
     \brief Appends a program to program chain.
@@ -84,45 +84,45 @@ void SamProgramChain::Add(std::vector<SamProgram>& programs) {
         Add(*pgIter);
 }
 
-/*! \fn SamProgramIterator SamProgramChain::Begin(void)
+/*! \fn SamProgramIterator SamProgramChain::Begin()
     \return an STL iterator pointing to the first (oldest) program record
     \sa ConstBegin(), End(), First()
 */
-SamProgramIterator SamProgramChain::Begin(void) {
+SamProgramIterator SamProgramChain::Begin() {
     return m_data.begin();
 }
 
-/*! \fn SamProgramConstIterator SamProgramChain::Begin(void) const
+/*! \fn SamProgramConstIterator SamProgramChain::Begin() const
     \return an STL const_iterator pointing to the first (oldest) program record
 
     This is an overloaded function.
 
     \sa ConstBegin(), End(), First()
 */
-SamProgramConstIterator SamProgramChain::Begin(void) const {
+SamProgramConstIterator SamProgramChain::Begin() const {
     return m_data.begin();
 }
 
-/*! \fn void SamProgramChain::Clear(void)
+/*! \fn void SamProgramChain::Clear()
     \brief Clears all program records.
 */
-void SamProgramChain::Clear(void) {
+void SamProgramChain::Clear() {
     m_data.clear();
 }
 
-/*! \fn SamProgramConstIterator SamProgramChain::ConstBegin(void) const
+/*! \fn SamProgramConstIterator SamProgramChain::ConstBegin() const
     \return an STL const_iterator pointing to the first (oldest) program record
     \sa Begin(), ConstEnd(), First()
 */
-SamProgramConstIterator SamProgramChain::ConstBegin(void) const {
+SamProgramConstIterator SamProgramChain::ConstBegin() const {
     return m_data.begin();
 }
 
-/*! \fn SamProgramConstIterator SamProgramChain::ConstEnd(void) const
+/*! \fn SamProgramConstIterator SamProgramChain::ConstEnd() const
     \return an STL const_iterator pointing to the imaginary entry after the last (newest) program record
     \sa ConstBegin(), End(), Last()
 */
-SamProgramConstIterator SamProgramChain::ConstEnd(void) const {
+SamProgramConstIterator SamProgramChain::ConstEnd() const {
     return m_data.end();
 }
 
@@ -148,26 +148,26 @@ bool SamProgramChain::Contains(const std::string& programId) const {
     return ( IndexOf(programId) != (int)m_data.size() );
 }
 
-/*! \fn SamProgramIterator SamProgramChain::End(void)
+/*! \fn SamProgramIterator SamProgramChain::End()
     \return an STL iterator pointing to the imaginary entry after the last (newest) program record
     \sa Begin(), ConstEnd(), Last()
 */
-SamProgramIterator SamProgramChain::End(void) {
+SamProgramIterator SamProgramChain::End() {
     return m_data.end();
 }
 
-/*! \fn SamProgramConstIterator SamProgramChain::End(void) const
+/*! \fn SamProgramConstIterator SamProgramChain::End() const
     \return an STL const_iterator pointing to the imaginary entry after the last (newest) program record
 
     This is an overloaded function.
 
     \sa Begin(), ConstEnd(), Last()
 */
-SamProgramConstIterator SamProgramChain::End(void) const {
+SamProgramConstIterator SamProgramChain::End() const {
     return m_data.end();
 }
 
-/*! \fn SamProgram& SamProgramChain::First(void)
+/*! \fn SamProgram& SamProgramChain::First()
     \brief Fetches first (oldest) record in the chain.
 
     \warning This function will fail if the chain is empty. If this is possible,
@@ -176,7 +176,7 @@ SamProgramConstIterator SamProgramChain::End(void) const {
     \return a modifiable reference to the first (oldest) program entry
     \sa Begin(), Last()
 */
-SamProgram& SamProgramChain::First(void) {
+SamProgram& SamProgramChain::First() {
 
     // find first record in container that has no PreviousProgramID entry
     SamProgramIterator iter = Begin();
@@ -192,7 +192,7 @@ SamProgram& SamProgramChain::First(void) {
     std::exit(EXIT_FAILURE);
 }
 
-/*! \fn const SamProgram& SamProgramChain::First(void) const
+/*! \fn const SamProgram& SamProgramChain::First() const
     \brief Fetches first (oldest) record in the chain.
 
     This is an overloaded function.
@@ -203,7 +203,7 @@ SamProgram& SamProgramChain::First(void) {
     \return a read-only reference to the first (oldest) program entry
     \sa Begin(), ConstBegin(), Last()
 */
-const SamProgram& SamProgramChain::First(void) const {
+const SamProgram& SamProgramChain::First() const {
 
     // find first record in container that has no PreviousProgramID entry
     SamProgramConstIterator iter = ConstBegin();
@@ -236,15 +236,15 @@ int SamProgramChain::IndexOf(const std::string& programId) const {
     return distance( begin, iter );
 }
 
-/*! \fn bool SamProgramChain::IsEmpty(void) const
+/*! \fn bool SamProgramChain::IsEmpty() const
     \brief Returns \c true if chain contains no records
     \sa Size()
 */
-bool SamProgramChain::IsEmpty(void) const {
+bool SamProgramChain::IsEmpty() const {
     return m_data.empty();
 }
 
-/*! \fn SamProgram& SamProgramChain::Last(void)
+/*! \fn SamProgram& SamProgramChain::Last()
     \brief Fetches last (newest) record in the chain.
 
     \warning This function will fail if the chain is empty. If this is possible,
@@ -253,7 +253,7 @@ bool SamProgramChain::IsEmpty(void) const {
     \return a modifiable reference to the last (newest) program entry
     \sa End(), First()
 */
-SamProgram& SamProgramChain::Last(void) {
+SamProgram& SamProgramChain::Last() {
     // find first record in container that has no NextProgramID entry
     SamProgramIterator iter = Begin();
     SamProgramIterator end  = End();
@@ -268,7 +268,7 @@ SamProgram& SamProgramChain::Last(void) {
     std::exit(EXIT_FAILURE);
 }
 
-/*! \fn const SamProgram& SamProgramChain::Last(void) const
+/*! \fn const SamProgram& SamProgramChain::Last() const
     \brief Fetches last (newest) record in the chain.
 
     This is an overloaded function.
@@ -279,7 +279,7 @@ SamProgram& SamProgramChain::Last(void) {
     \return a read-only reference to the last (newest) program entry
     \sa End(), ConstEnd(), First()
 */
-const SamProgram& SamProgramChain::Last(void) const {
+const SamProgram& SamProgramChain::Last() const {
     // find first record in container that has no NextProgramID entry
     SamProgramConstIterator iter = ConstBegin();
     SamProgramConstIterator end  = ConstEnd();
@@ -319,11 +319,11 @@ const std::string SamProgramChain::NextIdFor(const std::string& programId) const
     return std::string();
 }
 
-/*! \fn int SamProgramChain::Size(void) const
+/*! \fn int SamProgramChain::Size() const
     \brief Returns number of program records in the chain.
     \sa IsEmpty()
 */
-int SamProgramChain::Size(void) const {
+int SamProgramChain::Size() const {
     return m_data.size();
 }
 

--- a/src/api/SamProgramChain.h
+++ b/src/api/SamProgramChain.h
@@ -27,9 +27,9 @@ class API_EXPORT SamProgramChain {
 
     // ctor & dtor
     public:
-        SamProgramChain(void);
+        SamProgramChain();
         SamProgramChain(const SamProgramChain& other);
-        ~SamProgramChain(void);
+        ~SamProgramChain();
 
     // query/modify program data
     public:
@@ -38,37 +38,37 @@ class API_EXPORT SamProgramChain {
         void Add(std::vector<SamProgram>& programs);
 
         // clears all read group entries
-        void Clear(void);
+        void Clear();
 
         // returns true if chain contains this program record (matches on ID)
         bool Contains(const SamProgram& program) const;
         bool Contains(const std::string& programId) const;
 
         // returns the first (oldest) program in the chain
-        SamProgram& First(void);
-        const SamProgram& First(void) const;
+        SamProgram& First();
+        const SamProgram& First() const;
 
         // returns true if chain is empty
-        bool IsEmpty(void) const;
+        bool IsEmpty() const;
 
         // returns last (most recent) program in the chain
-        SamProgram& Last(void);
-        const SamProgram& Last(void) const;
+        SamProgram& Last();
+        const SamProgram& Last() const;
 
         // returns number of program records in the chain
-        int Size(void) const;
+        int Size() const;
 
         // retrieves a modifiable reference to the SamProgram object associated with this ID
         SamProgram& operator[](const std::string& programId);
 
     // retrieve STL-compatible iterators
     public:
-        SamProgramIterator      Begin(void);              // returns iterator to begin()
-        SamProgramConstIterator Begin(void) const;        // returns const_iterator to begin()
-        SamProgramConstIterator ConstBegin(void) const;   // returns const_iterator to begin()
-        SamProgramIterator      End(void);                // returns iterator to end()
-        SamProgramConstIterator End(void) const;          // returns const_iterator to end()
-        SamProgramConstIterator ConstEnd(void) const;     // returns const_iterator to end()
+        SamProgramIterator      Begin();              // returns iterator to begin()
+        SamProgramConstIterator Begin() const;        // returns const_iterator to begin()
+        SamProgramConstIterator ConstBegin() const;   // returns const_iterator to begin()
+        SamProgramIterator      End();                // returns iterator to end()
+        SamProgramConstIterator End() const;          // returns const_iterator to end()
+        SamProgramConstIterator ConstEnd() const;     // returns const_iterator to end()
 
     // internal methods
     private:

--- a/src/api/SamReadGroup.cpp
+++ b/src/api/SamReadGroup.cpp
@@ -56,10 +56,10 @@ using namespace BamTools;
     \brief corresponds to \@RG PL:\<SequencingTechnology\>
 */
 
-/*! \fn SamReadGroup::SamReadGroup(void)
+/*! \fn SamReadGroup::SamReadGroup()
     \brief default constructor
 */
-SamReadGroup::SamReadGroup(void)
+SamReadGroup::SamReadGroup()
     : Description("")
     , FlowOrder("")
     , ID("")
@@ -113,15 +113,15 @@ SamReadGroup::SamReadGroup(const SamReadGroup& other)
     , CustomTags(other.CustomTags)
 { }
 
-/*! \fn SamReadGroup::~SamReadGroup(void)
+/*! \fn SamReadGroup::~SamReadGroup()
     \brief destructor
 */
-SamReadGroup::~SamReadGroup(void) { }
+SamReadGroup::~SamReadGroup() { }
 
-/*! \fn void SamReadGroup::Clear(void)
+/*! \fn void SamReadGroup::Clear()
     \brief Clears all data fields.
 */
-void SamReadGroup::Clear(void) {
+void SamReadGroup::Clear() {
     Description.clear();
     FlowOrder.clear();
     ID.clear();
@@ -137,86 +137,86 @@ void SamReadGroup::Clear(void) {
     CustomTags.clear();
 }
 
-/*! \fn bool SamReadGroup::HasDescription(void) const
+/*! \fn bool SamReadGroup::HasDescription() const
     \brief Returns \c true if read group contains \@RG DS:\<Description\>
 */
-bool SamReadGroup::HasDescription(void) const {
+bool SamReadGroup::HasDescription() const {
     return (!Description.empty());
 }
 
-/*! \fn bool SamReadGroup::HasFlowOrder(void) const
+/*! \fn bool SamReadGroup::HasFlowOrder() const
     \brief Returns \c true if read group contains \@RG FO:\<FlowOrder\>
 */
-bool SamReadGroup::HasFlowOrder(void) const {
+bool SamReadGroup::HasFlowOrder() const {
     return (!FlowOrder.empty());
 }
 
-/*! \fn bool SamReadGroup::HasID(void) const
+/*! \fn bool SamReadGroup::HasID() const
     \brief Returns \c true if read group contains \@RG: ID:\<ID\>
 */
-bool SamReadGroup::HasID(void) const {
+bool SamReadGroup::HasID() const {
     return (!ID.empty());
 }
 
-/*! \fn bool SamReadGroup::HasKeySequence(void) const
+/*! \fn bool SamReadGroup::HasKeySequence() const
     \brief Returns \c true if read group contains \@RG KS:\<KeySequence\>
 */
-bool SamReadGroup::HasKeySequence(void) const {
+bool SamReadGroup::HasKeySequence() const {
     return (!KeySequence.empty());
 }
 
-/*! \fn bool SamReadGroup::HasLibrary(void) const
+/*! \fn bool SamReadGroup::HasLibrary() const
     \brief Returns \c true if read group contains \@RG LB:\<Library\>
 */
-bool SamReadGroup::HasLibrary(void) const {
+bool SamReadGroup::HasLibrary() const {
     return (!Library.empty());
 }
 
-/*! \fn bool SamReadGroup::HasPlatformUnit(void) const
+/*! \fn bool SamReadGroup::HasPlatformUnit() const
     \brief Returns \c true if read group contains \@RG PU:\<PlatformUnit\>
 */
-bool SamReadGroup::HasPlatformUnit(void) const {
+bool SamReadGroup::HasPlatformUnit() const {
     return (!PlatformUnit.empty());
 }
 
-/*! \fn bool SamReadGroup::HasPredictedInsertSize(void) const
+/*! \fn bool SamReadGroup::HasPredictedInsertSize() const
     \brief Returns \c true if read group contains \@RG PI:\<PredictedInsertSize\>
 */
-bool SamReadGroup::HasPredictedInsertSize(void) const {
+bool SamReadGroup::HasPredictedInsertSize() const {
     return (!PredictedInsertSize.empty());
 }
 
-/*! \fn bool SamReadGroup::HasProductionDate(void) const
+/*! \fn bool SamReadGroup::HasProductionDate() const
     \brief Returns \c true if read group contains \@RG DT:\<ProductionDate\>
 */
-bool SamReadGroup::HasProductionDate(void) const {
+bool SamReadGroup::HasProductionDate() const {
     return (!ProductionDate.empty());
 }
 
-/*! \fn bool SamReadGroup::HasProgram(void) const
+/*! \fn bool SamReadGroup::HasProgram() const
     \brief Returns \c true if read group contains \@RG PG:\<Program\>
 */
-bool SamReadGroup::HasProgram(void) const {
+bool SamReadGroup::HasProgram() const {
     return (!Program.empty());
 }
 
-/*! \fn bool SamReadGroup::HasSample(void) const
+/*! \fn bool SamReadGroup::HasSample() const
     \brief Returns \c true if read group contains \@RG SM:\<Sample\>
 */
-bool SamReadGroup::HasSample(void) const {
+bool SamReadGroup::HasSample() const {
     return (!Sample.empty());
 }
 
-/*! \fn bool SamReadGroup::HasSequencingCenter(void) const
+/*! \fn bool SamReadGroup::HasSequencingCenter() const
     \brief Returns \c true if read group contains \@RG CN:\<SequencingCenter\>
 */
-bool SamReadGroup::HasSequencingCenter(void) const {
+bool SamReadGroup::HasSequencingCenter() const {
     return (!SequencingCenter.empty());
 }
 
-/*! \fn bool SamReadGroup::HasSequencingTechnology(void) const
+/*! \fn bool SamReadGroup::HasSequencingTechnology() const
     \brief Returns \c true if read group contains \@RG PL:\<SequencingTechnology\>
 */
-bool SamReadGroup::HasSequencingTechnology(void) const {
+bool SamReadGroup::HasSequencingTechnology() const {
     return (!SequencingTechnology.empty());
 }

--- a/src/api/SamReadGroup.h
+++ b/src/api/SamReadGroup.h
@@ -20,27 +20,27 @@ namespace BamTools {
 struct API_EXPORT SamReadGroup {
 
     // ctor & dtor
-    SamReadGroup(void);
+    SamReadGroup();
     SamReadGroup(const std::string& id);
     SamReadGroup(const SamReadGroup& other);
-    ~SamReadGroup(void);
+    ~SamReadGroup();
 
     // query/modify entire read group
-    void Clear(void);                          // clears all data fields
+    void Clear();                          // clears all data fields
 
     // convenience query methods
-    bool HasDescription(void) const;           // returns true if read group has a description
-    bool HasFlowOrder(void) const;             // returns true if read group has a flow order entry
-    bool HasID(void) const;                    // returns true if read group has a group ID
-    bool HasKeySequence(void) const;           // returns true if read group has a key sequence
-    bool HasLibrary(void) const;               // returns true if read group has a library name
-    bool HasPlatformUnit(void) const;          // returns true if read group has a platform unit ID
-    bool HasPredictedInsertSize(void) const;   // returns true if read group has a predicted insert size
-    bool HasProductionDate(void) const;        // returns true if read group has a production date
-    bool HasProgram(void) const;               // returns true if read group has a program entry
-    bool HasSample(void) const;                // returns true if read group has a sample name
-    bool HasSequencingCenter(void) const;      // returns true if read group has a sequencing center ID
-    bool HasSequencingTechnology(void) const;  // returns true if read group has a sequencing technology ID
+    bool HasDescription() const;           // returns true if read group has a description
+    bool HasFlowOrder() const;             // returns true if read group has a flow order entry
+    bool HasID() const;                    // returns true if read group has a group ID
+    bool HasKeySequence() const;           // returns true if read group has a key sequence
+    bool HasLibrary() const;               // returns true if read group has a library name
+    bool HasPlatformUnit() const;          // returns true if read group has a platform unit ID
+    bool HasPredictedInsertSize() const;   // returns true if read group has a predicted insert size
+    bool HasProductionDate() const;        // returns true if read group has a production date
+    bool HasProgram() const;               // returns true if read group has a program entry
+    bool HasSample() const;                // returns true if read group has a sample name
+    bool HasSequencingCenter() const;      // returns true if read group has a sequencing center ID
+    bool HasSequencingTechnology() const;  // returns true if read group has a sequencing technology ID
 
 
     // data fields

--- a/src/api/SamReadGroupDictionary.cpp
+++ b/src/api/SamReadGroupDictionary.cpp
@@ -18,10 +18,10 @@ using namespace BamTools;
     Provides methods for operating on a collection of SamReadGroup entries.
 */
 
-/*! \fn SamReadGroupDictionary::SamReadGroupDictionary(void)
+/*! \fn SamReadGroupDictionary::SamReadGroupDictionary()
     \brief constructor
 */
-SamReadGroupDictionary::SamReadGroupDictionary(void) { }
+SamReadGroupDictionary::SamReadGroupDictionary() { }
 
 /*! \fn SamReadGroupDictionary::SamReadGroupDictionary(const SamReadGroupDictionary& other)
     \brief copy constructor
@@ -31,10 +31,10 @@ SamReadGroupDictionary::SamReadGroupDictionary(const SamReadGroupDictionary& oth
     , m_lookupData(other.m_lookupData)
 { }
 
-/*! \fn SamReadGroupDictionary::~SamReadGroupDictionary(void)
+/*! \fn SamReadGroupDictionary::~SamReadGroupDictionary()
     \brief destructor
 */
-SamReadGroupDictionary::~SamReadGroupDictionary(void) { }
+SamReadGroupDictionary::~SamReadGroupDictionary() { }
 
 /*! \fn void SamReadGroupDictionary::Add(const SamReadGroup& readGroup)
     \brief Appends a read group to the dictionary.
@@ -107,46 +107,46 @@ void SamReadGroupDictionary::Add(const std::vector<std::string>& readGroupIds) {
         Add(*rgIter);
 }
 
-/*! \fn SamReadGroupIterator SamReadGroupDictionary::Begin(void)
+/*! \fn SamReadGroupIterator SamReadGroupDictionary::Begin()
     \return an STL iterator pointing to the first read group
     \sa ConstBegin(), End()
 */
-SamReadGroupIterator SamReadGroupDictionary::Begin(void) {
+SamReadGroupIterator SamReadGroupDictionary::Begin() {
     return m_data.begin();
 }
 
-/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::Begin(void) const
+/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::Begin() const
     \return an STL const_iterator pointing to the first read group
 
     This is an overloaded function.
 
     \sa ConstBegin(), End()
 */
-SamReadGroupConstIterator SamReadGroupDictionary::Begin(void) const {
+SamReadGroupConstIterator SamReadGroupDictionary::Begin() const {
     return m_data.begin();
 }
 
-/*! \fn void SamReadGroupDictionary::Clear(void)
+/*! \fn void SamReadGroupDictionary::Clear()
     \brief Clears all read group entries.
 */
-void SamReadGroupDictionary::Clear(void) {
+void SamReadGroupDictionary::Clear() {
     m_data.clear();
     m_lookupData.clear();
 }
 
-/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::ConstBegin(void) const
+/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::ConstBegin() const
     \return an STL const_iterator pointing to the first read group
     \sa Begin(), ConstEnd()
 */
-SamReadGroupConstIterator SamReadGroupDictionary::ConstBegin(void) const {
+SamReadGroupConstIterator SamReadGroupDictionary::ConstBegin() const {
     return m_data.begin();
 }
 
-/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::ConstEnd(void) const
+/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::ConstEnd() const
     \return an STL const_iterator pointing to the imaginary entry after the last read group
     \sa ConstBegin(), End()
 */
-SamReadGroupConstIterator SamReadGroupDictionary::ConstEnd(void) const {
+SamReadGroupConstIterator SamReadGroupDictionary::ConstEnd() const {
     return m_data.end();
 }
 
@@ -172,30 +172,30 @@ bool SamReadGroupDictionary::Contains(const SamReadGroup& readGroup) const {
     return Contains(readGroup.ID);
 }
 
-/*! \fn SamReadGroupIterator SamReadGroupDictionary::End(void)
+/*! \fn SamReadGroupIterator SamReadGroupDictionary::End()
     \return an STL iterator pointing to the imaginary entry after the last read group
     \sa Begin(), ConstEnd()
 */
-SamReadGroupIterator SamReadGroupDictionary::End(void) {
+SamReadGroupIterator SamReadGroupDictionary::End() {
     return m_data.end();
 }
 
-/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::End(void) const
+/*! \fn SamReadGroupConstIterator SamReadGroupDictionary::End() const
     \return an STL const_iterator pointing to the imaginary entry after the last read group
 
     This is an overloaded function.
 
     \sa Begin(), ConstEnd()
 */
-SamReadGroupConstIterator SamReadGroupDictionary::End(void) const {
+SamReadGroupConstIterator SamReadGroupDictionary::End() const {
     return m_data.end();
 }
 
-/*! \fn bool SamReadGroupDictionary::IsEmpty(void) const
+/*! \fn bool SamReadGroupDictionary::IsEmpty() const
     \brief Returns \c true if dictionary contains no read groups
     \sa Size()
 */
-bool SamReadGroupDictionary::IsEmpty(void) const {
+bool SamReadGroupDictionary::IsEmpty() const {
     return m_data.empty();
 }
 
@@ -265,11 +265,11 @@ void SamReadGroupDictionary::Remove(const std::vector<std::string>& readGroupIds
         Remove(*rgIter);
 }
 
-/*! \fn int SamReadGroupDictionary::Size(void) const
+/*! \fn int SamReadGroupDictionary::Size() const
     \brief Returns number of read groups in dictionary.
     \sa IsEmpty()
 */
-int SamReadGroupDictionary::Size(void) const {
+int SamReadGroupDictionary::Size() const {
     return m_data.size();
 }
 

--- a/src/api/SamReadGroupDictionary.h
+++ b/src/api/SamReadGroupDictionary.h
@@ -26,9 +26,9 @@ class API_EXPORT SamReadGroupDictionary {
 
     // ctor & dtor
     public:
-        SamReadGroupDictionary(void);
+        SamReadGroupDictionary();
         SamReadGroupDictionary(const SamReadGroupDictionary& other);
-        ~SamReadGroupDictionary(void);
+        ~SamReadGroupDictionary();
 
     // query/modify read group data
     public:
@@ -42,14 +42,14 @@ class API_EXPORT SamReadGroupDictionary {
         void Add(const std::vector<std::string>& readGroupIds);
 
         // clears all read group entries
-        void Clear(void);
+        void Clear();
 
         // returns true if dictionary contains this read group
         bool Contains(const SamReadGroup& readGroup) const;
         bool Contains(const std::string& readGroupId) const;
 
         // returns true if dictionary is empty
-        bool IsEmpty(void) const;
+        bool IsEmpty() const;
 
         // removes read group, if found
         void Remove(const SamReadGroup& readGroup);
@@ -60,19 +60,19 @@ class API_EXPORT SamReadGroupDictionary {
         void Remove(const std::vector<std::string>& readGroupIds);
 
         // returns number of read groups in dictionary
-        int Size(void) const;
+        int Size() const;
 
         // retrieves a modifiable reference to the SamReadGroup object associated with this ID
         SamReadGroup& operator[](const std::string& readGroupId);
 
     // retrieve STL-compatible iterators
     public:
-        SamReadGroupIterator      Begin(void);              // returns iterator to begin()
-        SamReadGroupConstIterator Begin(void) const;        // returns const_iterator to begin()
-        SamReadGroupConstIterator ConstBegin(void) const;   // returns const_iterator to begin()
-        SamReadGroupIterator      End(void);                // returns iterator to end()
-        SamReadGroupConstIterator End(void) const;          // returns const_iterator to end()
-        SamReadGroupConstIterator ConstEnd(void) const;     // returns const_iterator to end()
+        SamReadGroupIterator      Begin();              // returns iterator to begin()
+        SamReadGroupConstIterator Begin() const;        // returns const_iterator to begin()
+        SamReadGroupConstIterator ConstBegin() const;   // returns const_iterator to begin()
+        SamReadGroupIterator      End();                // returns iterator to end()
+        SamReadGroupConstIterator End() const;          // returns const_iterator to end()
+        SamReadGroupConstIterator ConstEnd() const;     // returns const_iterator to end()
 
     // data members
     private:

--- a/src/api/SamSequence.cpp
+++ b/src/api/SamSequence.cpp
@@ -41,10 +41,10 @@ using namespace BamTools;
     \brief corresponds to \@SQ UR:\<URI\>
 */
 
-/*! \fn SamSequence::SamSequence(void)
+/*! \fn SamSequence::SamSequence()
     \brief default constructor
 */
-SamSequence::SamSequence(void)
+SamSequence::SamSequence()
     : AssemblyID("")
     , Checksum("")
     , Length("")
@@ -101,15 +101,15 @@ SamSequence::SamSequence(const SamSequence& other)
     , CustomTags(other.CustomTags)
 { }
 
-/*! \fn SamSequence::~SamSequence(void)
+/*! \fn SamSequence::~SamSequence()
     \brief destructor
 */
-SamSequence::~SamSequence(void) { }
+SamSequence::~SamSequence() { }
 
-/*! \fn void SamSequence::Clear(void)
+/*! \fn void SamSequence::Clear()
     \brief Clears all data fields.
 */
-void SamSequence::Clear(void) {
+void SamSequence::Clear() {
     AssemblyID.clear();
     Checksum.clear();
     Length.clear();
@@ -119,44 +119,44 @@ void SamSequence::Clear(void) {
     CustomTags.clear();
 }
 
-/*! \fn bool SamSequence::HasAssemblyID(void) const
+/*! \fn bool SamSequence::HasAssemblyID() const
     \brief Returns \c true if sequence contains \@SQ AS:\<AssemblyID\>
 */
-bool SamSequence::HasAssemblyID(void) const {
+bool SamSequence::HasAssemblyID() const {
     return (!AssemblyID.empty());
 }
 
-/*! \fn bool SamSequence::HasChecksum(void) const
+/*! \fn bool SamSequence::HasChecksum() const
     \brief Returns \c true if sequence contains \@SQ M5:\<Checksum\>
 */
-bool SamSequence::HasChecksum(void) const {
+bool SamSequence::HasChecksum() const {
     return (!Checksum.empty());
 }
 
-/*! \fn bool SamSequence::HasLength(void) const
+/*! \fn bool SamSequence::HasLength() const
     \brief Returns \c true if sequence contains \@SQ LN:\<Length\>
 */
-bool SamSequence::HasLength(void) const {
+bool SamSequence::HasLength() const {
     return (!Length.empty());
 }
 
-/*! \fn bool SamSequence::HasName(void) const
+/*! \fn bool SamSequence::HasName() const
     \brief Returns \c true if sequence contains \@SQ SN:\<Name\>
 */
-bool SamSequence::HasName(void) const {
+bool SamSequence::HasName() const {
     return (!Name.empty());
 }
 
-/*! \fn bool SamSequence::HasSpecies(void) const
+/*! \fn bool SamSequence::HasSpecies() const
     \brief Returns \c true if sequence contains \@SQ SP:\<Species\>
 */
-bool SamSequence::HasSpecies(void) const {
+bool SamSequence::HasSpecies() const {
     return (!Species.empty());
 }
 
-/*! \fn bool SamSequence::HasURI(void) const
+/*! \fn bool SamSequence::HasURI() const
     \brief Returns \c true if sequence contains \@SQ UR:\<URI\>
 */
-bool SamSequence::HasURI(void) const {
+bool SamSequence::HasURI() const {
     return (!URI.empty());
 }

--- a/src/api/SamSequence.h
+++ b/src/api/SamSequence.h
@@ -20,22 +20,22 @@ namespace BamTools {
 struct API_EXPORT SamSequence {
 
     // ctor & dtor
-    SamSequence(void);
+    SamSequence();
     SamSequence(const std::string& name, const int& length);
     SamSequence(const std::string& name, const std::string& length);
     SamSequence(const SamSequence& other);
-    ~SamSequence(void);
+    ~SamSequence();
 
     // query/modify entire sequence
-    void Clear(void);                // clears all contents
+    void Clear();                // clears all contents
 
     // convenience query methods
-    bool HasAssemblyID(void) const;  // returns true if sequence has an assembly ID
-    bool HasChecksum(void) const;    // returns true if sequence has an MD5 checksum
-    bool HasLength(void) const;      // returns true if sequence has a length
-    bool HasName(void) const;        // returns true if sequence has a name
-    bool HasSpecies(void) const;     // returns true if sequence has a species ID
-    bool HasURI(void) const;         // returns true if sequence has a URI
+    bool HasAssemblyID() const;  // returns true if sequence has an assembly ID
+    bool HasChecksum() const;    // returns true if sequence has an MD5 checksum
+    bool HasLength() const;      // returns true if sequence has a length
+    bool HasName() const;        // returns true if sequence has a name
+    bool HasSpecies() const;     // returns true if sequence has a species ID
+    bool HasURI() const;         // returns true if sequence has a URI
 
     // data members
     std::string AssemblyID;          // AS:<AssemblyID>

--- a/src/api/SamSequenceDictionary.cpp
+++ b/src/api/SamSequenceDictionary.cpp
@@ -18,10 +18,10 @@ using namespace BamTools;
     Provides methods for operating on a collection of SamSequence entries.
 */
 
-/*! \fn SamSequenceDictionary::SamSequenceDictionary(void)
+/*! \fn SamSequenceDictionary::SamSequenceDictionary()
     \brief constructor
 */
-SamSequenceDictionary::SamSequenceDictionary(void) { }
+SamSequenceDictionary::SamSequenceDictionary() { }
 
 /*! \fn SamSequenceDictionary::SamSequenceDictionary(const SamSequenceDictionary& other)
     \brief copy constructor
@@ -31,10 +31,10 @@ SamSequenceDictionary::SamSequenceDictionary(const SamSequenceDictionary& other)
     , m_lookupData(other.m_lookupData)
 { }
 
-/*! \fn SamSequenceDictionary::~SamSequenceDictionary(void)
+/*! \fn SamSequenceDictionary::~SamSequenceDictionary()
     \brief destructor
 */
-SamSequenceDictionary::~SamSequenceDictionary(void) { }
+SamSequenceDictionary::~SamSequenceDictionary() { }
 
 /*! \fn void SamSequenceDictionary::Add(const SamSequence& sequence)
     \brief Appends a sequence to the dictionary.
@@ -111,46 +111,46 @@ void SamSequenceDictionary::Add(const std::map<std::string, int>& sequenceMap) {
     }
 }
 
-/*! \fn SamSequenceIterator SamSequenceDictionary::Begin(void)
+/*! \fn SamSequenceIterator SamSequenceDictionary::Begin()
     \return an STL iterator pointing to the first sequence
     \sa ConstBegin(), End()
 */
-SamSequenceIterator SamSequenceDictionary::Begin(void) {
+SamSequenceIterator SamSequenceDictionary::Begin() {
     return m_data.begin();
 }
 
-/*! \fn SamSequenceConstIterator SamSequenceDictionary::Begin(void) const
+/*! \fn SamSequenceConstIterator SamSequenceDictionary::Begin() const
     \return an STL const_iterator pointing to the first sequence
 
     This is an overloaded function.
 
     \sa ConstBegin(), End()
 */
-SamSequenceConstIterator SamSequenceDictionary::Begin(void) const {
+SamSequenceConstIterator SamSequenceDictionary::Begin() const {
     return m_data.begin();
 }
 
-/*! \fn void SamSequenceDictionary::Clear(void)
+/*! \fn void SamSequenceDictionary::Clear()
     \brief Clears all sequence entries.
 */
-void SamSequenceDictionary::Clear(void) {
+void SamSequenceDictionary::Clear() {
     m_data.clear();
     m_lookupData.clear();
 }
 
-/*! \fn SamSequenceConstIterator SamSequenceDictionary::ConstBegin(void) const
+/*! \fn SamSequenceConstIterator SamSequenceDictionary::ConstBegin() const
     \return an STL const_iterator pointing to the first sequence
     \sa Begin(), ConstEnd()
 */
-SamSequenceConstIterator SamSequenceDictionary::ConstBegin(void) const {
+SamSequenceConstIterator SamSequenceDictionary::ConstBegin() const {
     return m_data.begin();
 }
 
-/*! \fn SamSequenceConstIterator SamSequenceDictionary::ConstEnd(void) const
+/*! \fn SamSequenceConstIterator SamSequenceDictionary::ConstEnd() const
     \return an STL const_iterator pointing to the imaginary entry after the last sequence
     \sa End(), ConstBegin()
 */
-SamSequenceConstIterator SamSequenceDictionary::ConstEnd(void) const {
+SamSequenceConstIterator SamSequenceDictionary::ConstEnd() const {
     return m_data.end();
 }
 
@@ -176,30 +176,30 @@ bool SamSequenceDictionary::Contains(const SamSequence& sequence) const {
     return Contains(sequence.Name);
 }
 
-/*! \fn SamSequenceIterator SamSequenceDictionary::End(void)
+/*! \fn SamSequenceIterator SamSequenceDictionary::End()
     \return an STL iterator pointing to the imaginary entry after the last sequence
     \sa Begin(), ConstEnd()
 */
-SamSequenceIterator SamSequenceDictionary::End(void) {
+SamSequenceIterator SamSequenceDictionary::End() {
     return m_data.end();
 }
 
-/*! \fn SamSequenceConstIterator SamSequenceDictionary::End(void) const
+/*! \fn SamSequenceConstIterator SamSequenceDictionary::End() const
     \return an STL const_iterator pointing to the imaginary entry after the last sequence
 
     This is an overloaded function.
 
     \sa Begin(), ConstEnd()
 */
-SamSequenceConstIterator SamSequenceDictionary::End(void) const {
+SamSequenceConstIterator SamSequenceDictionary::End() const {
     return m_data.end();
 }
 
-/*! \fn bool SamSequenceDictionary::IsEmpty(void) const
+/*! \fn bool SamSequenceDictionary::IsEmpty() const
     \brief Returns \c true if dictionary contains no sequences
     \sa Size()
 */
-bool SamSequenceDictionary::IsEmpty(void) const {
+bool SamSequenceDictionary::IsEmpty() const {
     return m_data.empty();
 }
 
@@ -269,11 +269,11 @@ void SamSequenceDictionary::Remove(const std::vector<std::string>& sequenceNames
         Remove(*rgIter);
 }
 
-/*! \fn int SamSequenceDictionary::Size(void) const
+/*! \fn int SamSequenceDictionary::Size() const
     \brief Returns number of sequences in dictionary.
     \sa IsEmpty()
 */
-int SamSequenceDictionary::Size(void) const {
+int SamSequenceDictionary::Size() const {
     return m_data.size();
 }
 

--- a/src/api/SamSequenceDictionary.h
+++ b/src/api/SamSequenceDictionary.h
@@ -26,9 +26,9 @@ class API_EXPORT SamSequenceDictionary {
 
     // ctor & dtor
     public:
-        SamSequenceDictionary(void);
+        SamSequenceDictionary();
         SamSequenceDictionary(const SamSequenceDictionary& other);
-        ~SamSequenceDictionary(void);
+        ~SamSequenceDictionary();
 
     // query/modify sequence data
     public:
@@ -42,14 +42,14 @@ class API_EXPORT SamSequenceDictionary {
         void Add(const std::map<std::string, int>& sequenceMap);
 
         // clears all sequence entries
-        void Clear(void);
+        void Clear();
 
         // returns true if dictionary contains this sequence
         bool Contains(const SamSequence& sequence) const;
         bool Contains(const std::string& sequenceName) const;
 
         // returns true if dictionary is empty
-        bool IsEmpty(void) const;
+        bool IsEmpty() const;
 
         // removes sequence, if found
         void Remove(const SamSequence& sequence);
@@ -60,19 +60,19 @@ class API_EXPORT SamSequenceDictionary {
         void Remove(const std::vector<std::string>& sequenceNames);
 
         // returns number of sequences in dictionary
-        int Size(void) const;
+        int Size() const;
 
         // retrieves a modifiable reference to the SamSequence object associated with this name
         SamSequence& operator[](const std::string& sequenceName);
 
     // retrieve STL-compatible iterators
     public:
-        SamSequenceIterator      Begin(void);               // returns iterator to begin()
-        SamSequenceConstIterator Begin(void) const;         // returns const_iterator to begin()
-        SamSequenceConstIterator ConstBegin(void) const;    // returns const_iterator to begin()
-        SamSequenceIterator      End(void);                 // returns iterator to end()
-        SamSequenceConstIterator End(void) const;           // returns const_iterator to end()
-        SamSequenceConstIterator ConstEnd(void) const;      // returns const_iterator to end()
+        SamSequenceIterator      Begin();               // returns iterator to begin()
+        SamSequenceConstIterator Begin() const;         // returns const_iterator to begin()
+        SamSequenceConstIterator ConstBegin() const;    // returns const_iterator to begin()
+        SamSequenceIterator      End();                 // returns iterator to end()
+        SamSequenceConstIterator End() const;           // returns const_iterator to end()
+        SamSequenceConstIterator ConstEnd() const;      // returns const_iterator to end()
 
     // data members
     private:

--- a/src/api/algorithms/Sort.h
+++ b/src/api/algorithms/Sort.h
@@ -81,7 +81,7 @@ struct API_EXPORT Sort {
         }
 
         // used by BamMultiReader internals
-        static inline bool UsesCharData(void) { return true; }
+        static inline bool UsesCharData() { return true; }
 
         // data members
         private:
@@ -127,7 +127,7 @@ struct API_EXPORT Sort {
         }
 
         // used by BamMultiReader internals
-        static inline bool UsesCharData(void) { return false; }
+        static inline bool UsesCharData() { return false; }
 
         // data members
         private:
@@ -174,7 +174,7 @@ struct API_EXPORT Sort {
         }
 
         // used by BamMultiReader internals
-        static inline bool UsesCharData(void) { return true; }
+        static inline bool UsesCharData() { return true; }
 
         // data members
         private:
@@ -201,7 +201,7 @@ struct API_EXPORT Sort {
         }
 
         // used by BamMultiReader internals
-        static inline bool UsesCharData(void) { return false; }
+        static inline bool UsesCharData() { return false; }
     };
 
     /*! Sorts a std::vector of alignments (in-place), using the provided compare function.

--- a/src/api/internal/bam/BamHeader_p.cpp
+++ b/src/api/internal/bam/BamHeader_p.cpp
@@ -33,10 +33,10 @@ bool isValidMagicNumber(const char* buffer) {
 // --------------------------
 
 // ctor
-BamHeader::BamHeader(void) { }
+BamHeader::BamHeader() { }
 
 // dtor
-BamHeader::~BamHeader(void) { }
+BamHeader::~BamHeader() { }
 
 // reads magic number from BGZF stream, returns true if valid
 void BamHeader::CheckMagicNumber(BgzfStream* stream) {
@@ -53,12 +53,12 @@ void BamHeader::CheckMagicNumber(BgzfStream* stream) {
 }
 
 // clear SamHeader data
-void BamHeader::Clear(void) {
+void BamHeader::Clear() {
     m_header.Clear();
 }
 
 // return true if SamHeader data is valid
-bool BamHeader::IsValid(void) const {
+bool BamHeader::IsValid() const {
     return m_header.IsValid();
 }
 
@@ -109,16 +109,16 @@ void BamHeader::ReadHeaderText(BgzfStream* stream, const uint32_t& length) {
 }
 
 // returns const-reference to SamHeader data object
-const SamHeader& BamHeader::ToConstSamHeader(void) const {
+const SamHeader& BamHeader::ToConstSamHeader() const {
     return m_header;
 }
 
 // returns *copy* of SamHeader data object
-SamHeader BamHeader::ToSamHeader(void) const {
+SamHeader BamHeader::ToSamHeader() const {
     return m_header;
 }
 
 // returns SAM-formatted string of header data
-std::string BamHeader::ToString(void) const {
+std::string BamHeader::ToString() const {
     return m_header.ToString();
 }

--- a/src/api/internal/bam/BamHeader_p.h
+++ b/src/api/internal/bam/BamHeader_p.h
@@ -32,24 +32,24 @@ class BamHeader {
 
     // ctor & dtor
     public:
-        BamHeader(void);
-        ~BamHeader(void);
+        BamHeader();
+        ~BamHeader();
 
     // BamHeader interface
     public:
         // clear SamHeader data
-        void Clear(void);
+        void Clear();
         // return true if SamHeader data is valid
-        bool IsValid(void) const;
+        bool IsValid() const;
         // load BAM header ('magic number' and SAM header text) from BGZF stream
         // returns true if all OK
         void Load(BgzfStream* stream);
         // returns (read-only) reference to SamHeader data object
-        const SamHeader& ToConstSamHeader(void) const;
+        const SamHeader& ToConstSamHeader() const;
         // returns (editable) copy of SamHeader data object
-        SamHeader ToSamHeader(void) const;
+        SamHeader ToSamHeader() const;
         // returns SAM-formatted string of header data
-        std::string ToString(void) const;
+        std::string ToString() const;
 
     // internal methods
     private:

--- a/src/api/internal/bam/BamMultiMerger_p.h
+++ b/src/api/internal/bam/BamMultiMerger_p.h
@@ -50,7 +50,7 @@ struct MergeItem {
         , Alignment(other.Alignment)
     { }
 
-    ~MergeItem(void) { }
+    ~MergeItem() { }
 };
 
 template<typename Compare>
@@ -75,16 +75,16 @@ struct MergeItemSorter : public std::binary_function<MergeItem, MergeItem, bool>
 class IMultiMerger {
 
     public:
-        IMultiMerger(void) { }
-        virtual ~IMultiMerger(void) { }
+        IMultiMerger() { }
+        virtual ~IMultiMerger() { }
     public:
         virtual void Add(MergeItem item) =0;
-        virtual void Clear(void) =0;
-        virtual const MergeItem& First(void) const =0;
-        virtual bool IsEmpty(void) const =0;
+        virtual void Clear() =0;
+        virtual const MergeItem& First() const =0;
+        virtual bool IsEmpty() const =0;
         virtual void Remove(BamReader* reader) =0;
-        virtual int Size(void) const =0;
-        virtual MergeItem TakeFirst(void) =0;
+        virtual int Size() const =0;
+        virtual MergeItem TakeFirst() =0;
 };
 
 // general merger
@@ -100,16 +100,16 @@ class MultiMerger : public IMultiMerger {
             : IMultiMerger()
             , m_data( MergeType(comp) )
         { }
-        ~MultiMerger(void) { }
+        ~MultiMerger() { }
 
     public:
         void Add(MergeItem item);
-        void Clear(void);
-        const MergeItem& First(void) const;
-        bool IsEmpty(void) const;
+        void Clear();
+        const MergeItem& First() const;
+        bool IsEmpty() const;
         void Remove(BamReader* reader);
-        int Size(void) const;
-        MergeItem TakeFirst(void);
+        int Size() const;
+        MergeItem TakeFirst();
 
     private:
         typedef MergeItem                              ValueType;
@@ -131,18 +131,18 @@ inline void MultiMerger<Compare>::Add(MergeItem item) {
 }
 
 template <typename Compare>
-inline void MultiMerger<Compare>::Clear(void) {
+inline void MultiMerger<Compare>::Clear() {
     m_data.clear();
 }
 
 template <typename Compare>
-inline const MergeItem& MultiMerger<Compare>::First(void) const {
+inline const MergeItem& MultiMerger<Compare>::First() const {
     const ValueType& entry = (*m_data.begin());
     return entry;
 }
 
 template <typename Compare>
-inline bool MultiMerger<Compare>::IsEmpty(void) const {
+inline bool MultiMerger<Compare>::IsEmpty() const {
     return m_data.empty();
 }
 template <typename Compare>
@@ -167,12 +167,12 @@ inline void MultiMerger<Compare>::Remove(BamReader* reader) {
     }
 }
 template <typename Compare>
-inline int MultiMerger<Compare>::Size(void) const {
+inline int MultiMerger<Compare>::Size() const {
     return m_data.size();
 }
 
 template <typename Compare>
-inline MergeItem MultiMerger<Compare>::TakeFirst(void) {
+inline MergeItem MultiMerger<Compare>::TakeFirst() {
     DataIterator firstIter = m_data.begin();
     MergeItem    firstItem = (*firstIter);
     m_data.erase(firstIter);
@@ -187,16 +187,16 @@ class MultiMerger<Algorithms::Sort::Unsorted> : public IMultiMerger {
         explicit MultiMerger(const Algorithms::Sort::Unsorted& comp = Algorithms::Sort::Unsorted())
             : IMultiMerger()
         { }
-        ~MultiMerger(void) { }
+        ~MultiMerger() { }
 
     public:
         void Add(MergeItem item);
-        void Clear(void);
-        const MergeItem& First(void) const;
-        bool IsEmpty(void) const;
+        void Clear();
+        const MergeItem& First() const;
+        bool IsEmpty() const;
         void Remove(BamReader* reader);
-        int Size(void) const;
-        MergeItem TakeFirst(void);
+        int Size() const;
+        MergeItem TakeFirst();
 
     private:
         typedef MergeItem                     ValueType;
@@ -212,17 +212,17 @@ void MultiMerger<Algorithms::Sort::Unsorted>::Add(MergeItem item) {
 }
 
 inline
-void MultiMerger<Algorithms::Sort::Unsorted>::Clear(void) {
+void MultiMerger<Algorithms::Sort::Unsorted>::Clear() {
     m_data.clear();
 }
 
 inline
-const MergeItem& MultiMerger<Algorithms::Sort::Unsorted>::First(void) const {
+const MergeItem& MultiMerger<Algorithms::Sort::Unsorted>::First() const {
     return m_data.front();
 }
 
 inline
-bool MultiMerger<Algorithms::Sort::Unsorted>::IsEmpty(void) const {
+bool MultiMerger<Algorithms::Sort::Unsorted>::IsEmpty() const {
     return m_data.empty();
 }
 
@@ -249,12 +249,12 @@ void MultiMerger<Algorithms::Sort::Unsorted>::Remove(BamReader* reader) {
 }
 
 inline
-int MultiMerger<Algorithms::Sort::Unsorted>::Size(void) const {
+int MultiMerger<Algorithms::Sort::Unsorted>::Size() const {
     return m_data.size();
 }
 
 inline
-MergeItem MultiMerger<Algorithms::Sort::Unsorted>::TakeFirst(void) {
+MergeItem MultiMerger<Algorithms::Sort::Unsorted>::TakeFirst() {
     MergeItem firstItem = m_data.front();
     m_data.pop_front();
     return firstItem;

--- a/src/api/internal/bam/BamMultiReader_p.cpp
+++ b/src/api/internal/bam/BamMultiReader_p.cpp
@@ -22,19 +22,19 @@ using namespace BamTools::Internal;
 #include <sstream>
 
 // ctor
-BamMultiReaderPrivate::BamMultiReaderPrivate(void)
+BamMultiReaderPrivate::BamMultiReaderPrivate()
     : m_alignmentCache(0)
     , m_hasUserMergeOrder(false)
     , m_mergeOrder(BamMultiReader::RoundRobinMerge)
 { }
 
 // dtor
-BamMultiReaderPrivate::~BamMultiReaderPrivate(void) {
+BamMultiReaderPrivate::~BamMultiReaderPrivate() {
     Close();
 }
 
 // close all BAM files
-bool BamMultiReaderPrivate::Close(void) {
+bool BamMultiReaderPrivate::Close() {
 
     m_errorString.clear();
 
@@ -170,7 +170,7 @@ bool BamMultiReaderPrivate::CreateIndexes(const BamIndex::IndexType& type) {
         return true;
 }
 
-IMultiMerger* BamMultiReaderPrivate::CreateAlignmentCache(void) {
+IMultiMerger* BamMultiReaderPrivate::CreateAlignmentCache() {
 
     // if no merge order set explicitly, use SAM header to lookup proper order
     if ( !m_hasUserMergeOrder ) {
@@ -212,7 +212,7 @@ IMultiMerger* BamMultiReaderPrivate::CreateAlignmentCache(void) {
     }
 }
 
-const std::vector<std::string> BamMultiReaderPrivate::Filenames(void) const {
+const std::vector<std::string> BamMultiReaderPrivate::Filenames() const {
 
     // init filename container
     std::vector<std::string> filenames;
@@ -236,17 +236,17 @@ const std::vector<std::string> BamMultiReaderPrivate::Filenames(void) const {
     return filenames;
 }
 
-std::string BamMultiReaderPrivate::GetErrorString(void) const {
+std::string BamMultiReaderPrivate::GetErrorString() const {
     return m_errorString;
 }
 
-SamHeader BamMultiReaderPrivate::GetHeader(void) const {
+SamHeader BamMultiReaderPrivate::GetHeader() const {
     const std::string& text = GetHeaderText();
     return SamHeader(text);
 }
 
 // makes a virtual, unified header for all the bam files in the multireader
-std::string BamMultiReaderPrivate::GetHeaderText(void) const {
+std::string BamMultiReaderPrivate::GetHeaderText() const {
 
     // N.B. - right now, simply copies all header data from first BAM,
     //        and then appends RG's from other BAM files
@@ -282,7 +282,7 @@ std::string BamMultiReaderPrivate::GetHeaderText(void) const {
     return mergedHeader.ToString();
 }
 
-BamMultiReader::MergeOrder BamMultiReaderPrivate::GetMergeOrder(void) const {
+BamMultiReader::MergeOrder BamMultiReaderPrivate::GetMergeOrder() const {
     return m_mergeOrder;
 }
 
@@ -307,7 +307,7 @@ bool BamMultiReaderPrivate::GetNextAlignmentCore(BamAlignment& al) {
 // ---------------------------------------------------------------------------------------
 
 // returns the number of reference sequences
-int BamMultiReaderPrivate::GetReferenceCount(void) const {
+int BamMultiReaderPrivate::GetReferenceCount() const {
 
     // handle empty multireader
     if ( m_readers.empty() ) return 0;
@@ -321,7 +321,7 @@ int BamMultiReaderPrivate::GetReferenceCount(void) const {
 }
 
 // returns vector of reference objects
-const RefVector BamMultiReaderPrivate::GetReferenceData(void) const {
+const RefVector BamMultiReaderPrivate::GetReferenceData() const {
 
     // handle empty multireader
     if ( m_readers.empty() ) return RefVector();
@@ -351,7 +351,7 @@ int BamMultiReaderPrivate::GetReferenceID(const std::string& refName) const {
 
 // returns true if all readers have index data available
 // this is useful to indicate whether Jump() or SetRegion() are possible
-bool BamMultiReaderPrivate::HasIndexes(void) const {
+bool BamMultiReaderPrivate::HasIndexes() const {
 
     // handle empty multireader
     if ( m_readers.empty() )
@@ -375,7 +375,7 @@ bool BamMultiReaderPrivate::HasIndexes(void) const {
 }
 
 // returns true if multireader has open readers
-bool BamMultiReaderPrivate::HasOpenReaders(void) {
+bool BamMultiReaderPrivate::HasOpenReaders() {
 
     // iterate over readers
     std::vector<MergeItem>::const_iterator readerIter = m_readers.begin();
@@ -604,7 +604,7 @@ bool BamMultiReaderPrivate::PopNextCachedAlignment(BamAlignment& al, const bool 
 }
 
 // returns BAM file pointers to beginning of alignment data & resets alignment cache
-bool BamMultiReaderPrivate::Rewind(void) {
+bool BamMultiReaderPrivate::Rewind() {
 
     // skip if no readers open
     if ( m_readers.empty() )
@@ -623,7 +623,7 @@ bool BamMultiReaderPrivate::Rewind(void) {
 }
 
 // returns BAM file pointers to beginning of alignment data
-bool BamMultiReaderPrivate::RewindReaders(void) {
+bool BamMultiReaderPrivate::RewindReaders() {
 
     m_errorString.clear();
     bool errorsEncountered = false;
@@ -723,7 +723,7 @@ bool BamMultiReaderPrivate::SetRegion(const BamRegion& region) {
 }
 
 // updates our alignment cache
-bool BamMultiReaderPrivate::UpdateAlignmentCache(void) {
+bool BamMultiReaderPrivate::UpdateAlignmentCache() {
 
     // create alignment cache if not created yet
     if ( m_alignmentCache == 0 ) {
@@ -758,7 +758,7 @@ bool BamMultiReaderPrivate::UpdateAlignmentCache(void) {
 // alignments against the same set of reference sequences, and that the
 // sequences are identically ordered.  If these checks fail the operation of
 // the multireader is undefined, so we force program exit.
-bool BamMultiReaderPrivate::ValidateReaders(void) const {
+bool BamMultiReaderPrivate::ValidateReaders() const {
 
     m_errorString.clear();
 

--- a/src/api/internal/bam/BamMultiReader_p.h
+++ b/src/api/internal/bam/BamMultiReader_p.h
@@ -37,56 +37,56 @@ class BamMultiReaderPrivate {
 
     // constructor / destructor
     public:
-        BamMultiReaderPrivate(void);
-        ~BamMultiReaderPrivate(void);
+        BamMultiReaderPrivate();
+        ~BamMultiReaderPrivate();
 
     // public interface
     public:
 
         // file operations
-        bool Close(void);
+        bool Close();
         bool CloseFile(const std::string& filename);
-        const std::vector<std::string> Filenames(void) const;
+        const std::vector<std::string> Filenames() const;
         bool Jump(int refID, int position = 0);
         bool Open(const std::vector<std::string>& filenames);
         bool OpenFile(const std::string& filename);
-        bool Rewind(void);
+        bool Rewind();
         bool SetRegion(const BamRegion& region);
 
         // access alignment data
-        BamMultiReader::MergeOrder GetMergeOrder(void) const;
+        BamMultiReader::MergeOrder GetMergeOrder() const;
         bool GetNextAlignment(BamAlignment& al);
         bool GetNextAlignmentCore(BamAlignment& al);
-        bool HasOpenReaders(void);
+        bool HasOpenReaders();
         bool SetExplicitMergeOrder(BamMultiReader::MergeOrder order);
 
         // access auxiliary data
-        SamHeader GetHeader(void) const;
-        std::string GetHeaderText(void) const;
-        int GetReferenceCount(void) const;
-        const BamTools::RefVector GetReferenceData(void) const;
+        SamHeader GetHeader() const;
+        std::string GetHeaderText() const;
+        int GetReferenceCount() const;
+        const BamTools::RefVector GetReferenceData() const;
         int GetReferenceID(const std::string& refName) const;
 
         // BAM index operations
         bool CreateIndexes(const BamIndex::IndexType& type = BamIndex::STANDARD);
-        bool HasIndexes(void) const;
+        bool HasIndexes() const;
         bool LocateIndexes(const BamIndex::IndexType& preferredType = BamIndex::STANDARD);
         bool OpenIndexes(const std::vector<std::string>& indexFilenames);
 
         // error handling
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
 
     // 'internal' methods
     public:
 
         bool CloseFiles(const std::vector<std::string>& filenames);
-        IMultiMerger* CreateAlignmentCache(void);
+        IMultiMerger* CreateAlignmentCache();
         bool PopNextCachedAlignment(BamAlignment& al, const bool needCharData);
-        bool RewindReaders(void);
+        bool RewindReaders();
         void SaveNextAlignment(BamReader* reader, BamAlignment* alignment);
         void SetErrorString(const std::string& where, const std::string& what) const; //
-        bool UpdateAlignmentCache(void);
-        bool ValidateReaders(void) const;
+        bool UpdateAlignmentCache();
+        bool ValidateReaders() const;
 
     // data members
     public:

--- a/src/api/internal/bam/BamRandomAccessController_p.cpp
+++ b/src/api/internal/bam/BamRandomAccessController_p.cpp
@@ -18,12 +18,12 @@ using namespace BamTools::Internal;
 #include <cassert>
 #include <sstream>
 
-BamRandomAccessController::BamRandomAccessController(void)
+BamRandomAccessController::BamRandomAccessController()
     : m_index(0)
     , m_hasAlignmentsInRegion(true)
 { }
 
-BamRandomAccessController::~BamRandomAccessController(void) {
+BamRandomAccessController::~BamRandomAccessController() {
     Close();
 }
 
@@ -127,19 +127,19 @@ BamRandomAccessController::AlignmentState(const BamAlignment& alignment) const {
     }
 }
 
-void BamRandomAccessController::Close(void) {
+void BamRandomAccessController::Close() {
     ClearIndex();
     ClearRegion();
 }
 
-void BamRandomAccessController::ClearIndex(void) {
+void BamRandomAccessController::ClearIndex() {
     if ( m_index ) {
         delete m_index;
         m_index = 0;
     }
 }
 
-void BamRandomAccessController::ClearRegion(void) {
+void BamRandomAccessController::ClearRegion() {
     m_region.clear();
     m_hasAlignmentsInRegion = true;
 }
@@ -177,15 +177,15 @@ bool BamRandomAccessController::CreateIndex(BamReaderPrivate* reader,
     return true;
 }
 
-std::string BamRandomAccessController::GetErrorString(void) const {
+std::string BamRandomAccessController::GetErrorString() const {
     return m_errorString;
 }
 
-bool BamRandomAccessController::HasIndex(void) const {
+bool BamRandomAccessController::HasIndex() const {
     return ( m_index != 0 );
 }
 
-bool BamRandomAccessController::HasRegion(void) const  {
+bool BamRandomAccessController::HasRegion() const  {
     return ( !m_region.isNull() );
 }
 
@@ -235,7 +235,7 @@ bool BamRandomAccessController::OpenIndex(const std::string& indexFilename, BamR
     return true;
 }
 
-bool BamRandomAccessController::RegionHasAlignments(void) const {
+bool BamRandomAccessController::RegionHasAlignments() const {
     return m_hasAlignmentsInRegion;
 }
 

--- a/src/api/internal/bam/BamRandomAccessController_p.h
+++ b/src/api/internal/bam/BamRandomAccessController_p.h
@@ -41,31 +41,31 @@ class BamRandomAccessController {
 
     // ctor & dtor
     public:
-        BamRandomAccessController(void);
-        ~BamRandomAccessController(void);
+        BamRandomAccessController();
+        ~BamRandomAccessController();
 
     // BamRandomAccessController interface
     public:
 
         // index methods
-        void ClearIndex(void);
+        void ClearIndex();
         bool CreateIndex(BamReaderPrivate* reader, const BamIndex::IndexType& type);
-        bool HasIndex(void) const;
+        bool HasIndex() const;
         bool IndexHasAlignmentsForReference(const int& refId);
         bool LocateIndex(BamReaderPrivate* reader, const BamIndex::IndexType& preferredType);
         bool OpenIndex(const std::string& indexFilename, BamReaderPrivate* reader);
         void SetIndex(BamIndex* index);
 
         // region methods
-        void ClearRegion(void);
-        bool HasRegion(void) const;
+        void ClearRegion();
+        bool HasRegion() const;
         RegionState AlignmentState(const BamAlignment& alignment) const;
-        bool RegionHasAlignments(void) const;
+        bool RegionHasAlignments() const;
         bool SetRegion(const BamRegion& region, const int& referenceCount);
 
         // general methods
-        void Close(void);
-        std::string GetErrorString(void) const;
+        void Close();
+        std::string GetErrorString() const;
 
     // internal methods
     private:

--- a/src/api/internal/bam/BamReader_p.cpp
+++ b/src/api/internal/bam/BamReader_p.cpp
@@ -35,12 +35,12 @@ BamReaderPrivate::BamReaderPrivate(BamReader* parent)
 }
 
 // destructor
-BamReaderPrivate::~BamReaderPrivate(void) {
+BamReaderPrivate::~BamReaderPrivate() {
     Close();
 }
 
 // closes the BAM file
-bool BamReaderPrivate::Close(void) {
+bool BamReaderPrivate::Close() {
 
     // clear BAM metadata
     m_references.clear();
@@ -89,25 +89,25 @@ bool BamReaderPrivate::CreateIndex(const BamIndex::IndexType& type) {
 }
 
 // return path & filename of current BAM file
-const std::string BamReaderPrivate::Filename(void) const {
+const std::string BamReaderPrivate::Filename() const {
     return m_filename;
 }
 
-const SamHeader& BamReaderPrivate::GetConstSamHeader(void) const {
+const SamHeader& BamReaderPrivate::GetConstSamHeader() const {
     return m_header.ToConstSamHeader();
 }
 
-std::string BamReaderPrivate::GetErrorString(void) const {
+std::string BamReaderPrivate::GetErrorString() const {
     return m_errorString;
 }
 
 // return header data as string
-std::string BamReaderPrivate::GetHeaderText(void) const {
+std::string BamReaderPrivate::GetHeaderText() const {
     return m_header.ToString();
 }
 
 // return header data as SamHeader object
-SamHeader BamReaderPrivate::GetSamHeader(void) const {
+SamHeader BamReaderPrivate::GetSamHeader() const {
     return m_header.ToSamHeader();
 }
 
@@ -193,11 +193,11 @@ bool BamReaderPrivate::GetNextAlignmentCore(BamAlignment& alignment) {
     }
 }
 
-int BamReaderPrivate::GetReferenceCount(void) const {
+int BamReaderPrivate::GetReferenceCount() const {
     return m_references.size();
 }
 
-const RefVector& BamReaderPrivate::GetReferenceData(void) const {
+const RefVector& BamReaderPrivate::GetReferenceData() const {
     return m_references;
 }
 
@@ -217,16 +217,16 @@ int BamReaderPrivate::GetReferenceID(const std::string& refName) const {
     else return index;
 }
 
-bool BamReaderPrivate::HasIndex(void) const {
+bool BamReaderPrivate::HasIndex() const {
     return m_randomAccessController.HasIndex();
 }
 
-bool BamReaderPrivate::IsOpen(void) const {
+bool BamReaderPrivate::IsOpen() const {
     return m_stream.IsOpen();
 }
 
 // load BAM header data
-void BamReaderPrivate::LoadHeaderData(void) {
+void BamReaderPrivate::LoadHeaderData() {
     m_header.Load(&m_stream);
 }
 
@@ -314,7 +314,7 @@ bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 }
 
 // loads reference data from BAM file
-bool BamReaderPrivate::LoadReferenceData(void) {
+bool BamReaderPrivate::LoadReferenceData() {
 
     // get number of reference sequences
     char buffer[sizeof(uint32_t)];
@@ -405,7 +405,7 @@ bool BamReaderPrivate::OpenIndex(const std::string& indexFilename) {
 }
 
 // returns BAM file pointer to beginning of alignment data
-bool BamReaderPrivate::Rewind(void) {
+bool BamReaderPrivate::Rewind() {
 
     // reset region
     m_randomAccessController.ClearRegion();
@@ -464,6 +464,6 @@ bool BamReaderPrivate::SetRegion(const BamRegion& region) {
     }
 }
 
-int64_t BamReaderPrivate::Tell(void) const {
+int64_t BamReaderPrivate::Tell() const {
     return m_stream.Tell();
 }

--- a/src/api/internal/bam/BamReader_p.h
+++ b/src/api/internal/bam/BamReader_p.h
@@ -37,17 +37,17 @@ class BamReaderPrivate {
     // ctor & dtor
     public:
         BamReaderPrivate(BamReader* parent);
-        ~BamReaderPrivate(void);
+        ~BamReaderPrivate();
 
     // BamReader interface
     public:
 
         // file operations
-        bool Close(void);
-        const std::string Filename(void) const;
-        bool IsOpen(void) const;
+        bool Close();
+        const std::string Filename() const;
+        bool IsOpen() const;
         bool Open(const std::string& filename);
-        bool Rewind(void);
+        bool Rewind();
         bool SetRegion(const BamRegion& region);
 
         // access alignment data
@@ -55,22 +55,22 @@ class BamReaderPrivate {
         bool GetNextAlignmentCore(BamAlignment& alignment);
 
         // access auxiliary data
-        std::string GetHeaderText(void) const;
-        const SamHeader& GetConstSamHeader(void) const;
-        SamHeader GetSamHeader(void) const;
-        int GetReferenceCount(void) const;
-        const RefVector& GetReferenceData(void) const;
+        std::string GetHeaderText() const;
+        const SamHeader& GetConstSamHeader() const;
+        SamHeader GetSamHeader() const;
+        int GetReferenceCount() const;
+        const RefVector& GetReferenceData() const;
         int GetReferenceID(const std::string& refName) const;
 
         // index operations
         bool CreateIndex(const BamIndex::IndexType& type);
-        bool HasIndex(void) const;
+        bool HasIndex() const;
         bool LocateIndex(const BamIndex::IndexType& preferredType);
         bool OpenIndex(const std::string& indexFilename);
         void SetIndex(BamIndex* index);
 
         // error handling
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
         void SetErrorString(const std::string& where, const std::string& what);
 
     // internal methods, but available as a BamReaderPrivate 'interface'
@@ -79,16 +79,16 @@ class BamReaderPrivate {
     // (currently only used by the BamIndex subclasses)
     public:
         // retrieves header text from BAM file
-        void LoadHeaderData(void);
+        void LoadHeaderData();
         // retrieves BAM alignment under file pointer
         // (does no overlap checking or character data parsing)
         bool LoadNextAlignment(BamAlignment& alignment);
         // builds reference data structure from BAM file
-        bool LoadReferenceData(void);
+        bool LoadReferenceData();
         // seek reader to file position
         bool Seek(const int64_t& position);
         // return reader's file position
-        int64_t Tell(void) const;
+        int64_t Tell() const;
 
     // data members
     public:

--- a/src/api/internal/bam/BamWriter_p.cpp
+++ b/src/api/internal/bam/BamWriter_p.cpp
@@ -19,12 +19,12 @@ using namespace BamTools::Internal;
 #include <cstring>
 
 // ctor
-BamWriterPrivate::BamWriterPrivate(void)
+BamWriterPrivate::BamWriterPrivate()
     : m_isBigEndian( BamTools::SystemIsBigEndian() )
 { }
 
 // dtor
-BamWriterPrivate::~BamWriterPrivate(void) {
+BamWriterPrivate::~BamWriterPrivate() {
     Close();
 }
 
@@ -40,7 +40,7 @@ uint32_t BamWriterPrivate::CalculateMinimumBin(const int begin, int end) const {
 }
 
 // closes the alignment archive
-void BamWriterPrivate::Close(void) {
+void BamWriterPrivate::Close() {
 
     // skip if file not open
     if ( !IsOpen() ) return;
@@ -142,12 +142,12 @@ void BamWriterPrivate::EncodeQuerySequence(const std::string& query, std::string
 }
 
 // returns a description of the last error that occurred
-std::string BamWriterPrivate::GetErrorString(void) const {
+std::string BamWriterPrivate::GetErrorString() const {
     return m_errorString;
 }
 
 // returns whether BAM file is open for writing or not
-bool BamWriterPrivate::IsOpen(void) const {
+bool BamWriterPrivate::IsOpen() const {
     return m_stream.IsOpen();
 }
 
@@ -427,7 +427,7 @@ void BamWriterPrivate::WriteCoreAlignment(const BamAlignment& al) {
                    al.SupportData.BlockLength-Constants::BAM_CORE_SIZE);
 }
 
-void BamWriterPrivate::WriteMagicNumber(void) {
+void BamWriterPrivate::WriteMagicNumber() {
     // write BAM file 'magic number'
     m_stream.Write(Constants::BAM_HEADER_MAGIC, Constants::BAM_HEADER_MAGIC_LENGTH);
 }

--- a/src/api/internal/bam/BamWriter_p.h
+++ b/src/api/internal/bam/BamWriter_p.h
@@ -35,14 +35,14 @@ class BamWriterPrivate {
 
     // ctor & dtor
     public:
-        BamWriterPrivate(void);
-        ~BamWriterPrivate(void);
+        BamWriterPrivate();
+        ~BamWriterPrivate();
 
     // interface methods
     public:
-        void Close(void);
-        std::string GetErrorString(void) const;
-        bool IsOpen(void) const;
+        void Close();
+        std::string GetErrorString() const;
+        bool IsOpen() const;
         bool Open(const std::string& filename,
                   const std::string& samHeaderText,
                   const BamTools::RefVector& referenceSequences);
@@ -56,7 +56,7 @@ class BamWriterPrivate {
         void EncodeQuerySequence(const std::string& query, std::string& encodedQuery);
         void WriteAlignment(const BamAlignment& al);
         void WriteCoreAlignment(const BamAlignment& al);
-        void WriteMagicNumber(void);
+        void WriteMagicNumber();
         void WriteReferences(const BamTools::RefVector& referenceSequences);
         void WriteSamHeaderText(const std::string& samHeaderText);
 

--- a/src/api/internal/index/BamStandardIndex_p.cpp
+++ b/src/api/internal/index/BamStandardIndex_p.cpp
@@ -37,12 +37,12 @@ const int BamStandardIndex::SIZEOF_LINEAROFFSET   = sizeof(uint64_t);
 // RaiiWrapper implementation
 // ----------------------------
 
-BamStandardIndex::RaiiWrapper::RaiiWrapper(void)
+BamStandardIndex::RaiiWrapper::RaiiWrapper()
     : Device(0)
     , Buffer(0)
 { }
 
-BamStandardIndex::RaiiWrapper::~RaiiWrapper(void) {
+BamStandardIndex::RaiiWrapper::~RaiiWrapper() {
 
     if ( Device ) {
         Device->Close();
@@ -69,7 +69,7 @@ BamStandardIndex::BamStandardIndex(Internal::BamReaderPrivate* reader)
 }
 
 // dtor
-BamStandardIndex::~BamStandardIndex(void) {
+BamStandardIndex::~BamStandardIndex() {
     CloseFile();
 }
 
@@ -223,7 +223,7 @@ void BamStandardIndex::CheckBufferSize(unsigned char*& buffer,
     }
 }
 
-void BamStandardIndex::CheckMagicNumber(void) {
+void BamStandardIndex::CheckMagicNumber() {
 
     // check 'magic number' to see if file is BAI index
     char magic[4];
@@ -242,7 +242,7 @@ void BamStandardIndex::ClearReferenceEntry(BaiReferenceEntry& refEntry) {
     refEntry.LinearOffsets.clear();
 }
 
-void BamStandardIndex::CloseFile(void) {
+void BamStandardIndex::CloseFile() {
 
     // close file stream
     if ( IsDeviceOpen() ) {
@@ -261,7 +261,7 @@ void BamStandardIndex::CloseFile(void) {
 }
 
 // builds index from associated BAM file & writes out to index file
-bool BamStandardIndex::Create(void) {
+bool BamStandardIndex::Create() {
 
     // skip if BamReader is invalid or not open
     if ( m_reader == 0 || !m_reader->IsOpen() ) {
@@ -419,7 +419,7 @@ bool BamStandardIndex::Create(void) {
 }
 
 // returns format's file extension
-const std::string BamStandardIndex::Extension(void) {
+const std::string BamStandardIndex::Extension() {
     return BamStandardIndex::BAI_EXTENSION;
 }
 
@@ -500,7 +500,7 @@ bool BamStandardIndex::HasAlignments(const int& referenceID) const {
     return ( refSummary.NumBins > 0 );
 }
 
-bool BamStandardIndex::IsDeviceOpen(void) const {
+bool BamStandardIndex::IsDeviceOpen() const {
     if ( m_resources.Device == 0 )
         return false;
     return m_resources.Device->IsOpen();
@@ -801,7 +801,7 @@ void BamStandardIndex::SummarizeBins(BaiReferenceSummary& refSummary) {
     SkipBins(numBins);
 }
 
-void BamStandardIndex::SummarizeIndexFile(void) {
+void BamStandardIndex::SummarizeIndexFile() {
 
     // load number of reference sequences
     int numReferences;
@@ -837,7 +837,7 @@ void BamStandardIndex::SummarizeReference(BaiReferenceSummary& refSummary) {
 }
 
 // return position of file pointer in index file stream
-int64_t BamStandardIndex::Tell(void) const {
+int64_t BamStandardIndex::Tell() const {
     return m_resources.Device->Tell();
 }
 
@@ -912,7 +912,7 @@ void BamStandardIndex::WriteBins(const int& refId, BaiBinMap& bins) {
         WriteBin( (*binIter).first, (*binIter).second );
 }
 
-void BamStandardIndex::WriteHeader(void) {
+void BamStandardIndex::WriteHeader() {
 
     int64_t numBytesWritten = 0;
 

--- a/src/api/internal/index/BamStandardIndex_p.h
+++ b/src/api/internal/index/BamStandardIndex_p.h
@@ -89,7 +89,7 @@ struct BaiReferenceSummary {
     uint64_t FirstLinearOffsetFilePosition;
 
     // ctor
-    BaiReferenceSummary(void)
+    BaiReferenceSummary()
         : NumBins(0)
         , NumLinearOffsets(0)
         , FirstBinFilePosition(0)
@@ -108,12 +108,12 @@ class BamStandardIndex : public BamIndex {
     // ctor & dtor
     public:
         BamStandardIndex(Internal::BamReaderPrivate* reader);
-        ~BamStandardIndex(void);
+        ~BamStandardIndex();
 
     // BamIndex implementation
     public:
         // builds index from associated BAM file & writes out to index file
-        bool Create(void);
+        bool Create();
         // returns whether reference has alignments or no
         bool HasAlignments(const int& referenceID) const;
         // attempts to use index data to jump to @region, returns success/fail
@@ -123,21 +123,21 @@ class BamStandardIndex : public BamIndex {
         bool Jump(const BamTools::BamRegion& region, bool* hasAlignmentsInRegion);
         // loads existing data from file into memory
         bool Load(const std::string& filename);
-        BamIndex::IndexType Type(void) const { return BamIndex::STANDARD; }
+        BamIndex::IndexType Type() const { return BamIndex::STANDARD; }
     public:
         // returns format's file extension
-        static const std::string Extension(void);
+        static const std::string Extension();
 
     // internal methods
     private:
 
         // index file ops
-        void CheckMagicNumber(void);
-        void CloseFile(void);
-        bool IsDeviceOpen(void) const;
+        void CheckMagicNumber();
+        void CloseFile();
+        bool IsDeviceOpen() const;
         void OpenFile(const std::string& filename, IBamIODevice::OpenMode mode);
         void Seek(const int64_t& position, const int origin);
-        int64_t Tell(void) const;
+        int64_t Tell() const;
 
         // BAI index building methods
         void ClearReferenceEntry(BaiReferenceEntry& refEntry);
@@ -170,7 +170,7 @@ class BamStandardIndex : public BamIndex {
         void SkipBins(const int& numBins);
         void SkipLinearOffsets(const int& numLinearOffsets);
         void SummarizeBins(BaiReferenceSummary& refSummary);
-        void SummarizeIndexFile(void);
+        void SummarizeIndexFile();
         void SummarizeLinearOffsets(BaiReferenceSummary& refSummary);
         void SummarizeReference(BaiReferenceSummary& refSummary);
 
@@ -191,7 +191,7 @@ class BamStandardIndex : public BamIndex {
         void WriteAlignmentChunks(BaiAlignmentChunkVector& chunks);
         void WriteBin(const uint32_t& binId, BaiAlignmentChunkVector& chunks);
         void WriteBins(const int& refId, BaiBinMap& bins);
-        void WriteHeader(void);
+        void WriteHeader();
         void WriteLinearOffsets(const int& refId, BaiLinearOffsetVector& linearOffsets);
         void WriteReferenceEntry(BaiReferenceEntry& refEntry);
 
@@ -205,8 +205,8 @@ class BamStandardIndex : public BamIndex {
         struct RaiiWrapper {
             IBamIODevice* Device;
             char* Buffer;
-            RaiiWrapper(void);
-            ~RaiiWrapper(void);
+            RaiiWrapper();
+            ~RaiiWrapper();
         };
         RaiiWrapper m_resources;
 

--- a/src/api/internal/index/BamToolsIndex_p.cpp
+++ b/src/api/internal/index/BamToolsIndex_p.cpp
@@ -37,11 +37,11 @@ const int BamToolsIndex::SIZEOF_BLOCK         = sizeof(int32_t)*2 + sizeof(int64
 // RaiiWrapper implementation
 // ----------------------------
 
-BamToolsIndex::RaiiWrapper::RaiiWrapper(void)
+BamToolsIndex::RaiiWrapper::RaiiWrapper()
     : Device(0)
 { }
 
-BamToolsIndex::RaiiWrapper::~RaiiWrapper(void) {
+BamToolsIndex::RaiiWrapper::~RaiiWrapper() {
     if ( Device ) {
         Device->Close();
         delete Device;
@@ -64,11 +64,11 @@ BamToolsIndex::BamToolsIndex(Internal::BamReaderPrivate* reader)
 }
 
 // dtor
-BamToolsIndex::~BamToolsIndex(void) {
+BamToolsIndex::~BamToolsIndex() {
     CloseFile();
 }
 
-void BamToolsIndex::CheckMagicNumber(void) {
+void BamToolsIndex::CheckMagicNumber() {
 
     // read magic number
     char magic[4];
@@ -82,7 +82,7 @@ void BamToolsIndex::CheckMagicNumber(void) {
 }
 
 // check index file version, return true if OK
-void BamToolsIndex::CheckVersion(void) {
+void BamToolsIndex::CheckVersion() {
 
     // read version from file
     const int64_t numBytesRead = m_resources.Device->Read((char*)&m_inputVersion, sizeof(m_inputVersion));
@@ -120,7 +120,7 @@ void BamToolsIndex::ClearReferenceEntry(BtiReferenceEntry& refEntry) {
     refEntry.Blocks.clear();
 }
 
-void BamToolsIndex::CloseFile(void) {
+void BamToolsIndex::CloseFile() {
     if ( IsDeviceOpen() ) {
         m_resources.Device->Close();
         delete m_resources.Device;
@@ -130,7 +130,7 @@ void BamToolsIndex::CloseFile(void) {
 }
 
 // builds index from associated BAM file & writes out to index file
-bool BamToolsIndex::Create(void) {
+bool BamToolsIndex::Create() {
 
     // skip if BamReader is invalid or not open
     if ( m_reader == 0 || !m_reader->IsOpen() ) {
@@ -274,7 +274,7 @@ bool BamToolsIndex::Create(void) {
 }
 
 // returns format's file extension
-const std::string BamToolsIndex::Extension(void) {
+const std::string BamToolsIndex::Extension() {
     return BamToolsIndex::BTI_EXTENSION;
 }
 
@@ -359,7 +359,7 @@ void BamToolsIndex::InitializeFileSummary(const int& numReferences) {
 }
 
 // returns true if the index stream is open
-bool BamToolsIndex::IsDeviceOpen(void) const {
+bool BamToolsIndex::IsDeviceOpen() const {
     if ( m_resources.Device == 0 )
         return false;
     return m_resources.Device->IsOpen();
@@ -421,7 +421,7 @@ bool BamToolsIndex::Load(const std::string& filename) {
     }
 }
 
-void BamToolsIndex::LoadFileSummary(void) {
+void BamToolsIndex::LoadFileSummary() {
 
     // load number of reference sequences
     int numReferences;
@@ -437,7 +437,7 @@ void BamToolsIndex::LoadFileSummary(void) {
         LoadReferenceSummary(*summaryIter);
 }
 
-void BamToolsIndex::LoadHeader(void) {
+void BamToolsIndex::LoadHeader() {
 
     // check BTI file metadata
     CheckMagicNumber();
@@ -557,7 +557,7 @@ void BamToolsIndex::SkipBlocks(const int& numBlocks) {
     Seek( numBlocks*BamToolsIndex::SIZEOF_BLOCK, SEEK_CUR );
 }
 
-int64_t BamToolsIndex::Tell(void) const {
+int64_t BamToolsIndex::Tell() const {
     return m_resources.Device->Tell();
 }
 
@@ -596,7 +596,7 @@ void BamToolsIndex::WriteBlocks(const BtiBlockVector& blocks) {
         WriteBlock(*blockIter);
 }
 
-void BamToolsIndex::WriteHeader(void) {
+void BamToolsIndex::WriteHeader() {
 
     int64_t numBytesWritten = 0 ;
 

--- a/src/api/internal/index/BamToolsIndex_p.h
+++ b/src/api/internal/index/BamToolsIndex_p.h
@@ -73,7 +73,7 @@ struct BtiReferenceSummary {
     uint64_t FirstBlockFilePosition;
 
     // ctor
-    BtiReferenceSummary(void)
+    BtiReferenceSummary()
         : NumBlocks(0)
         , FirstBlockFilePosition(0)
     { }
@@ -103,12 +103,12 @@ class BamToolsIndex : public BamIndex {
     // ctor & dtor
     public:
         BamToolsIndex(Internal::BamReaderPrivate* reader);
-        ~BamToolsIndex(void);
+        ~BamToolsIndex();
 
     // BamIndex implementation
     public:
         // builds index from associated BAM file & writes out to index file
-        bool Create(void);
+        bool Create();
         // returns whether reference has alignments or no
         bool HasAlignments(const int& referenceID) const;
         // attempts to use index data to jump to @region, returns success/fail
@@ -118,28 +118,28 @@ class BamToolsIndex : public BamIndex {
         bool Jump(const BamTools::BamRegion& region, bool* hasAlignmentsInRegion);
         // loads existing data from file into memory
         bool Load(const std::string& filename);
-        BamIndex::IndexType Type(void) const { return BamIndex::BAMTOOLS; }
+        BamIndex::IndexType Type() const { return BamIndex::BAMTOOLS; }
     public:
         // returns format's file extension
-        static const std::string Extension(void);
+        static const std::string Extension();
 
     // internal methods
     private:
 
         // index file ops
-        void CheckMagicNumber(void);
-        void CheckVersion(void);
-        void CloseFile(void);
-        bool IsDeviceOpen(void) const;
+        void CheckMagicNumber();
+        void CheckVersion();
+        void CloseFile();
+        bool IsDeviceOpen() const;
         void OpenFile(const std::string& filename, IBamIODevice::OpenMode mode);
         void Seek(const int64_t& position, const int origin);
-        int64_t Tell(void) const;
+        int64_t Tell() const;
 
         // index-creation methods
         void ClearReferenceEntry(BtiReferenceEntry& refEntry);
         void WriteBlock(const BtiBlock& block);
         void WriteBlocks(const BtiBlockVector& blocks);
-        void WriteHeader(void);
+        void WriteHeader();
         void WriteReferenceEntry(const BtiReferenceEntry& refEntry);
 
         // random-access methods
@@ -150,8 +150,8 @@ class BamToolsIndex : public BamIndex {
 
         // BTI summary data methods
         void InitializeFileSummary(const int& numReferences);
-        void LoadFileSummary(void);
-        void LoadHeader(void);
+        void LoadFileSummary();
+        void LoadHeader();
         void LoadNumBlocks(int& numBlocks);
         void LoadNumReferences(int& numReferences);
         void LoadReferenceSummary(BtiReferenceSummary& refSummary);
@@ -167,8 +167,8 @@ class BamToolsIndex : public BamIndex {
 
         struct RaiiWrapper {
             IBamIODevice* Device;
-            RaiiWrapper(void);
-            ~RaiiWrapper(void);
+            RaiiWrapper();
+            ~RaiiWrapper();
         };
         RaiiWrapper m_resources;
 

--- a/src/api/internal/io/BamFile_p.cpp
+++ b/src/api/internal/io/BamFile_p.cpp
@@ -19,16 +19,16 @@ BamFile::BamFile(const std::string& filename)
     , m_filename(filename)
 { }
 
-BamFile::~BamFile(void) { }
+BamFile::~BamFile() { }
 
-void BamFile::Close(void) {
+void BamFile::Close() {
     if ( IsOpen() ) {
         m_filename.clear();
         ILocalIODevice::Close();
     }
 }
 
-bool BamFile::IsRandomAccess(void) const {
+bool BamFile::IsRandomAccess() const {
     return true;
 }
 

--- a/src/api/internal/io/BamFile_p.h
+++ b/src/api/internal/io/BamFile_p.h
@@ -31,12 +31,12 @@ class BamFile : public ILocalIODevice {
     // ctor & dtor
     public:
         BamFile(const std::string& filename);
-        ~BamFile(void);
+        ~BamFile();
 
     // ILocalIODevice implementation
     public:
-        void Close(void);
-        bool IsRandomAccess(void) const;
+        void Close();
+        bool IsRandomAccess() const;
         bool Open(const IBamIODevice::OpenMode mode);
         bool Seek(const int64_t& position, const int origin = SEEK_SET);
 

--- a/src/api/internal/io/BamFtp_p.cpp
+++ b/src/api/internal/io/BamFtp_p.cpp
@@ -104,7 +104,7 @@ BamFtp::BamFtp(const std::string& url)
     ParseUrl(url);
 }
 
-BamFtp::~BamFtp(void) {
+BamFtp::~BamFtp() {
 
     // close connection & clean up
     Close();
@@ -114,7 +114,7 @@ BamFtp::~BamFtp(void) {
         delete m_dataSocket;
 }
 
-void BamFtp::Close(void) {
+void BamFtp::Close() {
 
     // disconnect socket
     m_commandSocket->DisconnectFromHost();
@@ -129,7 +129,7 @@ void BamFtp::Close(void) {
     m_dataPort = 0;
 }
 
-bool BamFtp::ConnectCommandSocket(void) {
+bool BamFtp::ConnectCommandSocket() {
 
     BT_ASSERT_X(m_commandSocket, "null command socket?");
 
@@ -170,7 +170,7 @@ bool BamFtp::ConnectCommandSocket(void) {
     return true;
 }
 
-bool BamFtp::ConnectDataSocket(void) {
+bool BamFtp::ConnectDataSocket() {
 
     // failure if can't connect to command socket first
     if ( !m_commandSocket->IsConnected() ) {
@@ -238,11 +238,11 @@ bool BamFtp::ConnectDataSocket(void) {
     return true;
 }
 
-bool BamFtp::IsOpen(void) const {
+bool BamFtp::IsOpen() const {
     return IBamIODevice::IsOpen() && m_isUrlParsed;
 }
 
-bool BamFtp::IsRandomAccess(void) const {
+bool BamFtp::IsRandomAccess() const {
     return true;
 }
 
@@ -262,7 +262,7 @@ bool BamFtp::Open(const IBamIODevice::OpenMode mode) {
     return ( ConnectCommandSocket() && ConnectDataSocket() );
 }
 
-bool BamFtp::ParsePassiveResponse(void) {
+bool BamFtp::ParsePassiveResponse() {
 
     // fail if empty
     if ( m_response.empty() )
@@ -374,7 +374,7 @@ int64_t BamFtp::ReadDataSocket(char* data, const unsigned int maxNumBytes) {
     return m_dataSocket->Read(data, maxNumBytes);
 }
 
-bool BamFtp::ReceiveReply(void) {
+bool BamFtp::ReceiveReply() {
 
     // failure if not connected
     if ( !m_commandSocket->IsConnected() ) {
@@ -461,7 +461,7 @@ bool BamFtp::SendCommand(const std::string& command, bool waitForReply) {
     return true;
 }
 
-int64_t BamFtp::Tell(void) const {
+int64_t BamFtp::Tell() const {
     return ( IsOpen() ? m_filePosition : -1 );
 }
 

--- a/src/api/internal/io/BamFtp_p.h
+++ b/src/api/internal/io/BamFtp_p.h
@@ -33,28 +33,28 @@ class BamFtp : public IBamIODevice {
     // ctor & dtor
     public:
         BamFtp(const std::string& url);
-        ~BamFtp(void);
+        ~BamFtp();
 
     // IBamIODevice implementation
     public:
-        void Close(void);
-        bool IsOpen(void) const;
-        bool IsRandomAccess(void) const;
+        void Close();
+        bool IsOpen() const;
+        bool IsRandomAccess() const;
         bool Open(const IBamIODevice::OpenMode mode);
         int64_t Read(char* data, const unsigned int numBytes);
         bool Seek(const int64_t& position, const int origin = SEEK_SET);
-        int64_t Tell(void) const;
+        int64_t Tell() const;
         int64_t Write(const char* data, const unsigned int numBytes);
 
     // internal methods
     private:
-        bool ConnectCommandSocket(void);
-        bool ConnectDataSocket(void);
-        bool ParsePassiveResponse(void);
+        bool ConnectCommandSocket();
+        bool ConnectDataSocket();
+        bool ParsePassiveResponse();
         void ParseUrl(const std::string& url);
         int64_t ReadCommandSocket(char* data, const unsigned int numBytes);
         int64_t ReadDataSocket(char* data, const unsigned int numBytes);
-        bool ReceiveReply(void);
+        bool ReceiveReply();
         bool SendCommand(const std::string& command, bool waitForReply);
         int64_t WriteCommandSocket(const char* data, const unsigned int numBytes);
         int64_t WriteDataSocket(const char* data, const unsigned int numBytes);

--- a/src/api/internal/io/BamHttp_p.cpp
+++ b/src/api/internal/io/BamHttp_p.cpp
@@ -83,7 +83,7 @@ BamHttp::BamHttp(const std::string& url)
     ParseUrl(url);
 }
 
-BamHttp::~BamHttp(void) {
+BamHttp::~BamHttp() {
 
     // close connection & clean up
     Close();
@@ -91,14 +91,14 @@ BamHttp::~BamHttp(void) {
         delete m_socket;
 }
 
-void BamHttp::ClearResponse(void) {
+void BamHttp::ClearResponse() {
     if ( m_response ) {
         delete m_response;
         m_response = 0;
     }
 }
 
-void BamHttp::Close(void) {
+void BamHttp::Close() {
 
     // disconnect socket & clear related resources
     DisconnectSocket();
@@ -111,7 +111,7 @@ void BamHttp::Close(void) {
     m_mode = IBamIODevice::NotOpen;
 }
 
-bool BamHttp::ConnectSocket(void) {
+bool BamHttp::ConnectSocket() {
 
     BT_ASSERT_X(m_socket, "null socket?");
 
@@ -125,7 +125,7 @@ bool BamHttp::ConnectSocket(void) {
     return true;
 }
 
-void BamHttp::DisconnectSocket(void) {
+void BamHttp::DisconnectSocket() {
 
     // disconnect socket & clean up
     m_socket->DisconnectFromHost();
@@ -136,17 +136,17 @@ void BamHttp::DisconnectSocket(void) {
     }
 }
 
-bool BamHttp::EnsureSocketConnection(void) {
+bool BamHttp::EnsureSocketConnection() {
     if ( m_socket->IsConnected() )
         return true;
     return ConnectSocket();
 }
 
-bool BamHttp::IsOpen(void) const {
+bool BamHttp::IsOpen() const {
     return IBamIODevice::IsOpen() && m_isUrlParsed;
 }
 
-bool BamHttp::IsRandomAccess(void) const {
+bool BamHttp::IsRandomAccess() const {
     return true;
 }
 
@@ -317,7 +317,7 @@ int64_t BamHttp::ReadFromSocket(char* data, const unsigned int maxNumBytes) {
     return m_socket->Read(data, maxNumBytes);
 }
 
-bool BamHttp::ReceiveResponse(void) {
+bool BamHttp::ReceiveResponse() {
 
     // fetch header, up until double new line
     std::string responseHeader;
@@ -478,7 +478,7 @@ bool BamHttp::SendGetRequest(const size_t numBytes) {
     return false;
 }
 
-bool BamHttp::SendHeadRequest(void) {
+bool BamHttp::SendHeadRequest() {
 
     // ensure clean slate
     ClearResponse();
@@ -523,7 +523,7 @@ bool BamHttp::SendHeadRequest(void) {
     return m_socket->GetError() == TcpSocket::NoError;
 }
 
-int64_t BamHttp::Tell(void) const {
+int64_t BamHttp::Tell() const {
     return ( IsOpen() ? m_filePosition : -1 );
 }
 

--- a/src/api/internal/io/BamHttp_p.h
+++ b/src/api/internal/io/BamHttp_p.h
@@ -35,30 +35,30 @@ class BamHttp : public IBamIODevice {
     // ctor & dtor
     public:
         BamHttp(const std::string& url);
-        ~BamHttp(void);
+        ~BamHttp();
 
     // IBamIODevice implementation
     public:
-        void Close(void);
-        bool IsOpen(void) const;
-        bool IsRandomAccess(void) const;
+        void Close();
+        bool IsOpen() const;
+        bool IsRandomAccess() const;
         bool Open(const IBamIODevice::OpenMode mode);
         int64_t Read(char* data, const unsigned int numBytes);
         bool Seek(const int64_t& position, const int origin = SEEK_SET);
-        int64_t Tell(void) const;
+        int64_t Tell() const;
         int64_t Write(const char* data, const unsigned int numBytes);
 
     // internal methods
     private:
-        void ClearResponse(void);
-        bool ConnectSocket(void);
-        void DisconnectSocket(void);
-        bool EnsureSocketConnection(void);
+        void ClearResponse();
+        bool ConnectSocket();
+        void DisconnectSocket();
+        bool EnsureSocketConnection();
         void ParseUrl(const std::string& url);
         int64_t ReadFromSocket(char* data, const unsigned int numBytes);
-        bool ReceiveResponse(void);
+        bool ReceiveResponse();
         bool SendGetRequest(const size_t numBytes = 0x10000);
-        bool SendHeadRequest(void);
+        bool SendHeadRequest();
         int64_t WriteToSocket(const char* data, const unsigned int numBytes);
 
     // data members

--- a/src/api/internal/io/BamPipe_p.cpp
+++ b/src/api/internal/io/BamPipe_p.cpp
@@ -14,11 +14,11 @@ using namespace BamTools::Internal;
 #include <cstdio>
 #include <iostream>
 
-BamPipe::BamPipe(void) : ILocalIODevice() { }
+BamPipe::BamPipe() : ILocalIODevice() { }
 
-BamPipe::~BamPipe(void) { }
+BamPipe::~BamPipe() { }
 
-bool BamPipe::IsRandomAccess(void) const {
+bool BamPipe::IsRandomAccess() const {
     return false;
 }
 

--- a/src/api/internal/io/BamPipe_p.h
+++ b/src/api/internal/io/BamPipe_p.h
@@ -30,12 +30,12 @@ class BamPipe : public ILocalIODevice {
 
     // ctor & dtor
     public:
-        BamPipe(void);
-        ~BamPipe(void);
+        BamPipe();
+        ~BamPipe();
 
     // IBamIODevice implementation
     public:
-        bool IsRandomAccess(void) const;
+        bool IsRandomAccess() const;
         bool Open(const IBamIODevice::OpenMode mode);
         bool Seek(const int64_t& position, const int origin = SEEK_SET);
 };

--- a/src/api/internal/io/BgzfStream_p.cpp
+++ b/src/api/internal/io/BgzfStream_p.cpp
@@ -29,7 +29,7 @@ using namespace BamTools::Internal;
 // ---------------------------
 
 // constructor
-BgzfStream::BgzfStream(void)
+BgzfStream::BgzfStream()
   : m_blockLength(0)
   , m_blockOffset(0)
   , m_blockAddress(0)
@@ -40,7 +40,7 @@ BgzfStream::BgzfStream(void)
 { }
 
 // destructor
-BgzfStream::~BgzfStream(void) {
+BgzfStream::~BgzfStream() {
     Close();
 }
 
@@ -57,7 +57,7 @@ bool BgzfStream::CheckBlockHeader(char* header) {
 }
 
 // closes BGZF file
-void BgzfStream::Close(void) {
+void BgzfStream::Close() {
 
     // skip if no device open
     if ( m_device == 0 ) return;
@@ -194,7 +194,7 @@ size_t BgzfStream::DeflateBlock(int32_t blockLength) {
 }
 
 // flushes the data in the BGZF block
-void BgzfStream::FlushBlock(void) {
+void BgzfStream::FlushBlock() {
 
     BT_ASSERT_X( m_device, "BgzfStream::FlushBlock() - attempting to flush to null device" );
 
@@ -261,7 +261,7 @@ size_t BgzfStream::InflateBlock(const size_t& blockLength) {
     return zs.total_out;
 }
 
-bool BgzfStream::IsOpen(void) const {
+bool BgzfStream::IsOpen() const {
     if ( m_device == 0 )
         return false;
     return m_device->IsOpen();
@@ -334,7 +334,7 @@ size_t BgzfStream::Read(char* data, const size_t dataLength) {
 }
 
 // reads a BGZF block
-void BgzfStream::ReadBlock(void) {
+void BgzfStream::ReadBlock() {
 
     BT_ASSERT_X( m_device, "BgzfStream::ReadBlock() - trying to read from null IO device");
 
@@ -425,7 +425,7 @@ void BgzfStream::SetWriteCompressed(bool ok) {
 }
 
 // get file position in BGZF file
-int64_t BgzfStream::Tell(void) const {
+int64_t BgzfStream::Tell() const {
     if ( !IsOpen() )
         return 0;
     return ( (m_blockAddress << 16) | (m_blockOffset & 0xFFFF) );

--- a/src/api/internal/io/BgzfStream_p.h
+++ b/src/api/internal/io/BgzfStream_p.h
@@ -34,15 +34,15 @@ class BgzfStream {
 
     // constructor & destructor
     public:
-        BgzfStream(void);
-        ~BgzfStream(void);
+        BgzfStream();
+        ~BgzfStream();
 
     // main interface methods
     public:
         // closes BGZF file
-        void Close(void);
+        void Close();
         // returns true if BgzfStream open for IO
-        bool IsOpen(void) const;
+        bool IsOpen() const;
         // opens the BGZF file
         void Open(const std::string& filename, const IBamIODevice::OpenMode mode);
         // reads BGZF data into a byte buffer
@@ -54,7 +54,7 @@ class BgzfStream {
         // enable/disable compressed output
         void SetWriteCompressed(bool ok);
         // get file position in BGZF file
-        int64_t Tell(void) const;
+        int64_t Tell() const;
         // writes the supplied data into the BGZF buffer
         size_t Write(const char* data, const size_t dataLength);
 
@@ -63,11 +63,11 @@ class BgzfStream {
         // compresses the current block
         size_t DeflateBlock(int32_t blockLength);
         // flushes the data in the BGZF block
-        void FlushBlock(void);
+        void FlushBlock();
         // de-compresses the current block
         size_t InflateBlock(const size_t& blockLength);
         // reads a BGZF block
-        void ReadBlock(void);
+        void ReadBlock();
 
     // static 'utility' methods
     public:

--- a/src/api/internal/io/ByteArray_p.cpp
+++ b/src/api/internal/io/ByteArray_p.cpp
@@ -18,7 +18,7 @@ using namespace BamTools::Internal;
 // ByteArray implementation
 // --------------------------
 
-ByteArray::ByteArray(void)
+ByteArray::ByteArray()
     : m_data()
 { }
 
@@ -39,22 +39,22 @@ ByteArray::ByteArray(const ByteArray& other)
     : m_data(other.m_data)
 { }
 
-ByteArray::~ByteArray(void) { }
+ByteArray::~ByteArray() { }
 
 ByteArray& ByteArray::operator=(const ByteArray& other) {
     m_data = other.m_data;
     return *this;
 }
 
-void ByteArray::Clear(void) {
+void ByteArray::Clear() {
     m_data.clear();
 }
 
-const char* ByteArray::ConstData(void) const {
+const char* ByteArray::ConstData() const {
     return &m_data[0];
 }
 
-char* ByteArray::Data(void) {
+char* ByteArray::Data() {
     return &m_data[0];
 }
 
@@ -100,11 +100,11 @@ void ByteArray::Resize(size_t n) {
     m_data.resize(n, 0);
 }
 
-size_t ByteArray::Size(void) const {
+size_t ByteArray::Size() const {
     return m_data.size();
 }
 
-void ByteArray::Squeeze(void) {
+void ByteArray::Squeeze() {
     std::vector<char> t(m_data);
     t.swap(m_data);
 }

--- a/src/api/internal/io/ByteArray_p.h
+++ b/src/api/internal/io/ByteArray_p.h
@@ -32,12 +32,12 @@ class ByteArray {
 
     // ctors & dtor
     public:
-        ByteArray(void);
+        ByteArray();
         ByteArray(const std::string& value);
         ByteArray(const std::vector<char>& value);
         ByteArray(const char* value, size_t n);
         ByteArray(const ByteArray& other);
-        ~ByteArray(void);
+        ~ByteArray();
 
         ByteArray& operator=(const ByteArray& other);
 
@@ -45,18 +45,18 @@ class ByteArray {
     public:
 
         // data access
-        const char* ConstData(void) const;
-        char* Data(void);
+        const char* ConstData() const;
+        char* Data();
         const char& operator[](size_t i) const;
         char& operator[](size_t i);
 
         // byte array manipulation
-        void Clear(void);
+        void Clear();
         size_t IndexOf(const char c, const size_t from = 0, const size_t to = 0) const;
         ByteArray& Remove(size_t from, size_t n);
         void Resize(size_t n);
-        size_t Size(void) const;
-        void Squeeze(void);
+        size_t Size() const;
+        void Squeeze();
 
     // data members
     private:

--- a/src/api/internal/io/HostAddress_p.cpp
+++ b/src/api/internal/io/HostAddress_p.cpp
@@ -190,7 +190,7 @@ bool ParseIp6(const std::string& address, uint8_t* maybeIp6 ) {
 // HostAddress implementation
 // ----------------------------
 
-HostAddress::HostAddress(void)
+HostAddress::HostAddress()
     : m_protocol(HostAddress::UnknownNetworkProtocol)
     , m_ip4Address(0)
     , m_hasIpAddress(true)
@@ -235,7 +235,7 @@ HostAddress::HostAddress(const HostAddress& other)
     , m_hasIpAddress(other.m_hasIpAddress)
 { }
 
-HostAddress::~HostAddress(void) { }
+HostAddress::~HostAddress() { }
 
 bool HostAddress::operator==(const HostAddress& other) const {
 
@@ -275,7 +275,7 @@ bool HostAddress::operator<(const HostAddress& other) const {
     return m_protocol < other.m_protocol;
 }
 
-void HostAddress::Clear(void) {
+void HostAddress::Clear() {
 
     m_protocol = HostAddress::UnknownNetworkProtocol;
     m_ip4Address = 0;
@@ -289,23 +289,23 @@ void HostAddress::Clear(void) {
     m_hasIpAddress = true;
 }
 
-bool HostAddress::HasIPAddress(void) const {
+bool HostAddress::HasIPAddress() const {
     return m_hasIpAddress;
 }
 
-bool HostAddress::IsNull(void) const {
+bool HostAddress::IsNull() const {
     return m_protocol == HostAddress::UnknownNetworkProtocol;
 }
 
-uint32_t HostAddress::GetIPv4Address(void) const {
+uint32_t HostAddress::GetIPv4Address() const {
     return m_ip4Address;
 }
 
-IPv6Address HostAddress::GetIPv6Address(void) const {
+IPv6Address HostAddress::GetIPv6Address() const {
     return m_ip6Address;
 }
 
-std::string HostAddress::GetIPString(void) const {
+std::string HostAddress::GetIPString() const {
 
     std::stringstream ss;
 
@@ -333,11 +333,11 @@ std::string HostAddress::GetIPString(void) const {
     return ss.str();
 }
 
-HostAddress::NetworkProtocol HostAddress::GetProtocol(void) const {
+HostAddress::NetworkProtocol HostAddress::GetProtocol() const {
     return m_protocol;
 }
 
-bool HostAddress::ParseAddress(void) {
+bool HostAddress::ParseAddress() {
 
     // all IPv6 addresses should have a ':'
     std::string s = m_ipString;

--- a/src/api/internal/io/HostAddress_p.h
+++ b/src/api/internal/io/HostAddress_p.h
@@ -30,7 +30,7 @@ namespace Internal {
 struct IPv6Address {
 
     // ctor
-    inline IPv6Address(void) { memset(&data, 0, sizeof(uint8_t)*16); }
+    inline IPv6Address() { memset(&data, 0, sizeof(uint8_t)*16); }
 
     // data access (no bounds checking)
     inline uint8_t& operator[](size_t index)       { return data[index]; }
@@ -51,24 +51,24 @@ class HostAddress {
 
     // ctors & dtor
     public:
-        HostAddress(void);
+        HostAddress();
         explicit HostAddress(const uint32_t ip4Address);
         explicit HostAddress(const uint8_t* ip6Address);
         explicit HostAddress(const IPv6Address& ip6Address);
         explicit HostAddress(const std::string& address);
         HostAddress(const HostAddress& other);
-        ~HostAddress(void);
+        ~HostAddress();
 
     // HostAddress interface
     public:
-        void Clear(void);
-        bool HasIPAddress(void) const; // returns whether string address could be converted to IP address
-        bool IsNull(void) const;
+        void Clear();
+        bool HasIPAddress() const; // returns whether string address could be converted to IP address
+        bool IsNull() const;
 
-        uint32_t    GetIPv4Address(void) const;
-        IPv6Address GetIPv6Address(void) const;
-        std::string GetIPString(void) const;
-        HostAddress::NetworkProtocol GetProtocol(void) const;
+        uint32_t    GetIPv4Address() const;
+        IPv6Address GetIPv6Address() const;
+        std::string GetIPString() const;
+        HostAddress::NetworkProtocol GetProtocol() const;
 
         void SetAddress(const uint32_t ip4Address);
         void SetAddress(const uint8_t* ip6Address);
@@ -83,7 +83,7 @@ class HostAddress {
 
     // internal methods
     private:
-        bool ParseAddress(void);
+        bool ParseAddress();
 
     // data members
     private:

--- a/src/api/internal/io/HostInfo_p.cpp
+++ b/src/api/internal/io/HostInfo_p.cpp
@@ -27,7 +27,7 @@ using namespace BamTools::Internal;
 // HostInfo implementation
 // -------------------------
 
-HostInfo::HostInfo(void)
+HostInfo::HostInfo()
     : m_error(HostInfo::NoError)
 { }
 
@@ -38,21 +38,21 @@ HostInfo::HostInfo(const HostInfo& other)
     , m_errorString(other.m_errorString)
 { }
 
-HostInfo::~HostInfo(void) { }
+HostInfo::~HostInfo() { }
 
-std::vector<HostAddress> HostInfo::Addresses(void) const {
+std::vector<HostAddress> HostInfo::Addresses() const {
     return m_addresses;
 }
 
-HostInfo::ErrorType HostInfo::GetError(void) const {
+HostInfo::ErrorType HostInfo::GetError() const {
     return m_error;
 }
 
-std::string HostInfo::GetErrorString(void) const {
+std::string HostInfo::GetErrorString() const {
     return m_errorString;
 }
 
-std::string HostInfo::HostName(void) const {
+std::string HostInfo::HostName() const {
     return m_hostName;
 }
 

--- a/src/api/internal/io/HostInfo_p.h
+++ b/src/api/internal/io/HostInfo_p.h
@@ -37,20 +37,20 @@ class HostInfo {
 
     // ctors & dtor
     public:
-        HostInfo(void);
+        HostInfo();
         HostInfo(const HostInfo& other);
-        ~HostInfo(void);
+        ~HostInfo();
 
     // HostInfo interface
     public:
-        std::string HostName(void) const;
+        std::string HostName() const;
         void SetHostName(const std::string& name);
 
-        std::vector<HostAddress> Addresses(void) const;
+        std::vector<HostAddress> Addresses() const;
         void SetAddresses(const std::vector<HostAddress>& addresses);
 
-        HostInfo::ErrorType GetError(void) const;
-        std::string GetErrorString(void) const;
+        HostInfo::ErrorType GetError() const;
+        std::string GetErrorString() const;
 
     // internal methods
     private:

--- a/src/api/internal/io/HttpHeader_p.cpp
+++ b/src/api/internal/io/HttpHeader_p.cpp
@@ -95,7 +95,7 @@ static std::string Trim(const std::string& source) {
 // HttpHeader implementation
 // ---------------------------
 
-HttpHeader::HttpHeader(void)
+HttpHeader::HttpHeader()
     : m_isValid(true)
     , m_majorVersion(1)
     , m_minorVersion(1)
@@ -109,17 +109,17 @@ HttpHeader::HttpHeader(const std::string& s)
     Parse(s);
 }
 
-HttpHeader::~HttpHeader(void) { }
+HttpHeader::~HttpHeader() { }
 
 bool HttpHeader::ContainsKey(const std::string& key) const {
     return ( m_fields.find(key) != m_fields.end() );
 }
 
-int HttpHeader::GetMajorVersion(void) const {
+int HttpHeader::GetMajorVersion() const {
     return m_majorVersion;
 }
 
-int HttpHeader::GetMinorVersion(void) const {
+int HttpHeader::GetMinorVersion() const {
     return m_minorVersion;
 }
 
@@ -129,7 +129,7 @@ std::string HttpHeader::GetValue(const std::string& key) {
     else return std::string();
 }
 
-bool HttpHeader::IsValid(void) const {
+bool HttpHeader::IsValid() const {
     return m_isValid;
 }
 
@@ -211,7 +211,7 @@ void HttpHeader::SetVersion(int major, int minor) {
     m_minorVersion = minor;
 }
 
-std::string HttpHeader::ToString(void) const {
+std::string HttpHeader::ToString() const {
     std::string result;
     if ( m_isValid ) {
         std::map<std::string, std::string>::const_iterator fieldIter = m_fields.begin();
@@ -242,13 +242,13 @@ HttpRequestHeader::HttpRequestHeader(const std::string& method,
     SetVersion(majorVersion, minorVersion);
 }
 
-HttpRequestHeader::~HttpRequestHeader(void) { }
+HttpRequestHeader::~HttpRequestHeader() { }
 
-std::string HttpRequestHeader::GetMethod(void) const {
+std::string HttpRequestHeader::GetMethod() const {
     return m_method;
 }
 
-std::string HttpRequestHeader::GetResource(void) const {
+std::string HttpRequestHeader::GetResource() const {
     return m_resource;
 }
 
@@ -292,7 +292,7 @@ bool HttpRequestHeader::ParseLine(const std::string& line, int lineNumber) {
     return true;
 }
 
-std::string HttpRequestHeader::ToString(void) const {
+std::string HttpRequestHeader::ToString() const {
     std::stringstream request;
     request << m_method   << Constants::SPACE_CHAR
             << m_resource << Constants::SPACE_CHAR
@@ -326,13 +326,13 @@ HttpResponseHeader::HttpResponseHeader(const std::string& s)
     Parse(s);
 }
 
-HttpResponseHeader::~HttpResponseHeader(void) { }
+HttpResponseHeader::~HttpResponseHeader() { }
 
-std::string HttpResponseHeader::GetReason(void) const  {
+std::string HttpResponseHeader::GetReason() const  {
     return m_reason;
 }
 
-int HttpResponseHeader::GetStatusCode(void) const {
+int HttpResponseHeader::GetStatusCode() const {
     return m_statusCode;
 }
 
@@ -381,7 +381,7 @@ bool HttpResponseHeader::ParseLine(const std::string& line, int lineNumber) {
     return true;
 }
 
-std::string HttpResponseHeader::ToString(void) const {
+std::string HttpResponseHeader::ToString() const {
     std::stringstream response;
     response << Constants::HTTP_STRING << GetMajorVersion() << Constants::DOT_CHAR << GetMinorVersion()
              << Constants::SPACE_CHAR  << m_statusCode

--- a/src/api/internal/io/HttpHeader_p.h
+++ b/src/api/internal/io/HttpHeader_p.h
@@ -32,9 +32,9 @@ class HttpHeader {
 
     // ctors & dtor
     public:
-        HttpHeader(void);
+        HttpHeader();
         HttpHeader(const std::string& s);
-        virtual ~HttpHeader(void);
+        virtual ~HttpHeader();
 
     // HttpHeader interface
     public:
@@ -46,14 +46,14 @@ class HttpHeader {
         void SetField(const std::string& key, const std::string& value);
 
         // get formatted header string
-        virtual std::string ToString(void) const;
+        virtual std::string ToString() const;
 
         // query HTTP version used
-        int GetMajorVersion(void) const;
-        int GetMinorVersion(void) const;
+        int GetMajorVersion() const;
+        int GetMinorVersion() const;
 
         // see if header was parsed OK
-        bool IsValid(void) const;
+        bool IsValid() const;
 
     // internal methods
     protected:
@@ -79,16 +79,16 @@ class HttpRequestHeader : public HttpHeader {
                           const std::string& resource,    // filename
                           int majorVersion = 1,           // version info
                           int minorVersion = 1);
-        ~HttpRequestHeader(void);
+        ~HttpRequestHeader();
 
     // HttpRequestHeader interface
     public:
-        std::string GetMethod(void) const;
-        std::string GetResource(void) const;
+        std::string GetMethod() const;
+        std::string GetResource() const;
 
     // HttpHeader implementation
     public:
-        std::string ToString(void) const;
+        std::string ToString() const;
     protected:
         bool ParseLine(const std::string& line, int lineNumber);
 
@@ -107,16 +107,16 @@ class HttpResponseHeader : public HttpHeader {
                            int majorVersion = 1,                       // version info
                            int minorVersion = 1);
         HttpResponseHeader(const std::string& s);
-        ~HttpResponseHeader(void);
+        ~HttpResponseHeader();
 
     // HttpRequestHeader interface
     public:
-        std::string GetReason(void) const;
-        int GetStatusCode(void) const;
+        std::string GetReason() const;
+        int GetStatusCode() const;
 
     // HttpHeader implementation
     public:
-        std::string ToString(void) const;
+        std::string ToString() const;
     protected:
         bool ParseLine(const std::string& line, int lineNumber);
 

--- a/src/api/internal/io/ILocalIODevice_p.cpp
+++ b/src/api/internal/io/ILocalIODevice_p.cpp
@@ -13,16 +13,16 @@ using namespace BamTools::Internal;
 
 #include <cstdio>
 
-ILocalIODevice::ILocalIODevice(void)
+ILocalIODevice::ILocalIODevice()
     : IBamIODevice()
     , m_stream(0)
 { }
 
-ILocalIODevice::~ILocalIODevice(void) {
+ILocalIODevice::~ILocalIODevice() {
     Close();
 }
 
-void ILocalIODevice::Close(void) {
+void ILocalIODevice::Close() {
 
     // skip if not open
     if ( !IsOpen() )
@@ -43,7 +43,7 @@ int64_t ILocalIODevice::Read(char* data, const unsigned int numBytes) {
     return static_cast<int64_t>( fread(data, sizeof(char), numBytes, m_stream) );
 }
 
-int64_t ILocalIODevice::Tell(void) const {
+int64_t ILocalIODevice::Tell() const {
     BT_ASSERT_X( m_stream, "ILocalIODevice::Tell: trying to get file position fromnull stream" );
     return ftell64(m_stream);
 }

--- a/src/api/internal/io/ILocalIODevice_p.h
+++ b/src/api/internal/io/ILocalIODevice_p.h
@@ -29,14 +29,14 @@ class ILocalIODevice : public IBamIODevice {
 
     // ctor & dtor
     public:
-        ILocalIODevice(void);
-        virtual ~ILocalIODevice(void);
+        ILocalIODevice();
+        virtual ~ILocalIODevice();
 
     // IBamIODevice implementation
     public:
-        virtual void Close(void);
+        virtual void Close();
         virtual int64_t Read(char* data, const unsigned int numBytes);
-        virtual int64_t Tell(void) const;
+        virtual int64_t Tell() const;
         virtual int64_t Write(const char* data, const unsigned int numBytes);
 
     // data members

--- a/src/api/internal/io/NetWin_p.h
+++ b/src/api/internal/io/NetWin_p.h
@@ -41,12 +41,12 @@ namespace Internal {
 // use RAII to ensure WSA is initialized
 class WindowsSockInit {
     public:
-        WindowsSockInit(void) {
+        WindowsSockInit() {
             WSAData wsadata;
             WSAStartup(MAKEWORD(2,2), &wsadata); // catch error ?
         }
 
-        ~WindowsSockInit(void) {
+        ~WindowsSockInit() {
             WSACleanup();
         }
 };

--- a/src/api/internal/io/RollingBuffer_p.cpp
+++ b/src/api/internal/io/RollingBuffer_p.cpp
@@ -34,9 +34,9 @@ RollingBuffer::RollingBuffer(size_t growth)
     Clear();
 }
 
-RollingBuffer::~RollingBuffer(void) { }
+RollingBuffer::~RollingBuffer() { }
 
-size_t RollingBuffer::BlockSize(void) const {
+size_t RollingBuffer::BlockSize() const {
 
     // if only one byte array in buffer <- needed?
     if ( m_tailBufferIndex == 0 )
@@ -47,7 +47,7 @@ size_t RollingBuffer::BlockSize(void) const {
     return first.Size() - m_head;
 }
 
-bool RollingBuffer::CanReadLine(void) const {
+bool RollingBuffer::CanReadLine() const {
     return IndexOf('\n') != std::string::npos;
 }
 
@@ -95,7 +95,7 @@ void RollingBuffer::Chop(size_t n) {
         Clear();
 }
 
-void RollingBuffer::Clear(void) {
+void RollingBuffer::Clear() {
 
     // remove all byte arrays (except first)
     m_data.erase( m_data.begin()+1, m_data.end() );
@@ -196,7 +196,7 @@ size_t RollingBuffer::IndexOf(char c) const {
     return std::string::npos;
 }
 
-bool RollingBuffer::IsEmpty(void) const {
+bool RollingBuffer::IsEmpty() const {
     return (m_tailBufferIndex == 0) && (m_tail == 0);
 }
 
@@ -245,7 +245,7 @@ size_t RollingBuffer::ReadLine(char* dest, size_t max) {
     return bytesReadSoFar;
 }
 
-const char* RollingBuffer::ReadPointer(void) const {
+const char* RollingBuffer::ReadPointer() const {
 
     // return null if empty buffer
     if ( m_data.empty() )
@@ -303,7 +303,7 @@ char* RollingBuffer::Reserve(size_t n) {
     return m_data[m_tailBufferIndex].Data();
 }
 
-size_t RollingBuffer::Size(void) const {
+size_t RollingBuffer::Size() const {
     return m_totalBufferSize;
 }
 

--- a/src/api/internal/io/RollingBuffer_p.h
+++ b/src/api/internal/io/RollingBuffer_p.h
@@ -37,25 +37,25 @@ class RollingBuffer {
     // ctors & dtor
     public:
         RollingBuffer(size_t growth);
-        ~RollingBuffer(void);
+        ~RollingBuffer();
 
     // RollingBuffer interface
     public:
 
         // returns current buffer size
-        size_t BlockSize(void) const;
+        size_t BlockSize() const;
         // checks buffer for new line
-        bool CanReadLine(void) const;
+        bool CanReadLine() const;
         // frees @n bytes from end of buffer
         void Chop(size_t n);
         // clears entire buffer structure
-        void Clear(void);
+        void Clear();
         // frees @n bytes from front of buffer
         void Free(size_t n);
         // checks buffer for @c
         size_t IndexOf(char c) const;
         // returns whether buffer contains data
-        bool IsEmpty(void) const;
+        bool IsEmpty() const;
         // reads up to @maxLen bytes into @dest
         // returns exactly how many bytes were read from buffer
         size_t Read(char* dest, size_t max);
@@ -63,11 +63,11 @@ class RollingBuffer {
         // returns exactly how many bytes were read from buffer
         size_t ReadLine(char* dest, size_t max);
         // returns a C-fxn compatible char* to byte data
-        const char* ReadPointer(void) const;
+        const char* ReadPointer() const;
         // ensures that buffer contains space for @n incoming bytes, returns write-able char*
         char* Reserve(size_t n);
         // returns current number of bytes stored in buffer
-        size_t Size(void) const;
+        size_t Size() const;
         // reserves space for @n bytes, then appends contents of @src to buffer
         void Write(const char* src, size_t n);
 

--- a/src/api/internal/io/TcpSocketEngine_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_p.cpp
@@ -17,7 +17,7 @@
 using namespace BamTools;
 using namespace BamTools::Internal;
 
-TcpSocketEngine::TcpSocketEngine(void)
+TcpSocketEngine::TcpSocketEngine()
     : m_socketDescriptor(-1)
 //    , m_localPort(0)
     , m_remotePort(0)
@@ -36,11 +36,11 @@ TcpSocketEngine::TcpSocketEngine(const TcpSocketEngine& other)
     , m_errorString(other.m_errorString)
 { }
 
-TcpSocketEngine::~TcpSocketEngine(void) {
+TcpSocketEngine::~TcpSocketEngine() {
     Close();
 }
 
-void TcpSocketEngine::Close(void) {
+void TcpSocketEngine::Close() {
 
     // close socket if we have valid FD
     if ( m_socketDescriptor != -1 ) {
@@ -77,35 +77,35 @@ bool TcpSocketEngine::Connect(const HostAddress& address, const uint16_t port) {
     return true;
 }
 
-std::string TcpSocketEngine::GetErrorString(void) const {
+std::string TcpSocketEngine::GetErrorString() const {
     return m_errorString;
 }
 
-//HostAddress TcpSocketEngine::GetLocalAddress(void) const {
+//HostAddress TcpSocketEngine::GetLocalAddress() const {
 //    return m_localAddress;
 //}
 
-//uint16_t TcpSocketEngine::GetLocalPort(void) const {
+//uint16_t TcpSocketEngine::GetLocalPort() const {
 //    return m_localPort;
 //}
 
-HostAddress TcpSocketEngine::GetRemoteAddress(void) const {
+HostAddress TcpSocketEngine::GetRemoteAddress() const {
     return m_remoteAddress;
 }
 
-uint16_t TcpSocketEngine::GetRemotePort(void) const {
+uint16_t TcpSocketEngine::GetRemotePort() const {
     return m_remotePort;
 }
 
-int TcpSocketEngine::GetSocketDescriptor(void) const {
+int TcpSocketEngine::GetSocketDescriptor() const {
     return m_socketDescriptor;
 }
 
-TcpSocket::SocketError TcpSocketEngine::GetSocketError(void) {
+TcpSocket::SocketError TcpSocketEngine::GetSocketError() {
     return m_socketError;
 }
 
-TcpSocket::SocketState TcpSocketEngine::GetSocketState(void) {
+TcpSocket::SocketState TcpSocketEngine::GetSocketState() {
     return m_socketState;
 }
 
@@ -119,11 +119,11 @@ bool TcpSocketEngine::Initialize(HostAddress::NetworkProtocol protocol) {
     return nativeCreateSocket(protocol);
 }
 
-bool TcpSocketEngine::IsValid(void) const {
+bool TcpSocketEngine::IsValid() const {
     return (m_socketDescriptor != -1);
 }
 
-int64_t TcpSocketEngine::NumBytesAvailable(void) const {
+int64_t TcpSocketEngine::NumBytesAvailable() const {
 
     // return 0 if socket FD is invalid
     if ( !IsValid() ) {

--- a/src/api/internal/io/TcpSocketEngine_p.h
+++ b/src/api/internal/io/TcpSocketEngine_p.h
@@ -34,21 +34,21 @@ class TcpSocketEngine {
 
     // ctors & dtor
     public:
-        TcpSocketEngine(void);
+        TcpSocketEngine();
         TcpSocketEngine(const TcpSocketEngine& other);
-        ~TcpSocketEngine(void);
+        ~TcpSocketEngine();
 
     // TcpSocketEngine interface
     public:
 
         // connection-related methods
-        void Close(void);
+        void Close();
         bool Connect(const HostAddress& address, const uint16_t port);
         bool Initialize(HostAddress::NetworkProtocol protocol);
-        bool IsValid(void) const;
+        bool IsValid() const;
 
         // IO-related methods
-        int64_t NumBytesAvailable(void) const;
+        int64_t NumBytesAvailable() const;
         int64_t Read(char* dest, size_t max);
         int64_t Write(const char* data, size_t length);
 
@@ -56,25 +56,25 @@ class TcpSocketEngine {
         bool WaitForWrite(int msec, bool* timedOut);
 
         // query connection state
-//        HostAddress GetLocalAddress(void) const;
-//        uint16_t GetLocalPort(void) const;
-        HostAddress GetRemoteAddress(void) const;
-        uint16_t    GetRemotePort(void) const;
+//        HostAddress GetLocalAddress() const;
+//        uint16_t GetLocalPort() const;
+        HostAddress GetRemoteAddress() const;
+        uint16_t    GetRemotePort() const;
 
-        int GetSocketDescriptor(void) const;
-        TcpSocket::SocketError GetSocketError(void);
-        TcpSocket::SocketState GetSocketState(void);
+        int GetSocketDescriptor() const;
+        TcpSocket::SocketError GetSocketError();
+        TcpSocket::SocketState GetSocketState();
 
-        std::string GetErrorString(void) const;
+        std::string GetErrorString() const;
 
     // platform-dependent internal methods
     // provided in the corresponding TcpSocketEngine_<OS>_p.cpp
     private:
-        void    nativeClose(void);
+        void    nativeClose();
         bool    nativeConnect(const HostAddress& address, const uint16_t port);
         bool    nativeCreateSocket(HostAddress::NetworkProtocol protocol);
-        void    nativeDisconnect(void);
-        int64_t nativeNumBytesAvailable(void) const;
+        void    nativeDisconnect();
+        int64_t nativeNumBytesAvailable() const;
         int64_t nativeRead(char* dest, size_t max);
         int     nativeSelect(int msecs, bool isRead) const;
         int64_t nativeWrite(const char* data, size_t length);

--- a/src/api/internal/io/TcpSocketEngine_unix_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_unix_p.cpp
@@ -34,7 +34,7 @@ namespace Internal {
 // TcpSocketEngine implementation
 // --------------------------------
 
-void TcpSocketEngine::nativeClose(void) {
+void TcpSocketEngine::nativeClose() {
     close(m_socketDescriptor);
 }
 
@@ -175,7 +175,7 @@ bool TcpSocketEngine::nativeCreateSocket(HostAddress::NetworkProtocol protocol) 
     return true;
 }
 
-int64_t TcpSocketEngine::nativeNumBytesAvailable(void) const {
+int64_t TcpSocketEngine::nativeNumBytesAvailable() const {
 
     // fetch number of bytes, return 0 on error
     int numBytes(0);

--- a/src/api/internal/io/TcpSocketEngine_win_p.cpp
+++ b/src/api/internal/io/TcpSocketEngine_win_p.cpp
@@ -20,7 +20,7 @@ using namespace BamTools::Internal;
 // TcpSocketEngine implementation
 // --------------------------------
 
-void TcpSocketEngine::nativeClose(void) {
+void TcpSocketEngine::nativeClose() {
     closesocket(m_socketDescriptor);
 }
 
@@ -167,7 +167,7 @@ bool TcpSocketEngine::nativeCreateSocket(HostAddress::NetworkProtocol protocol) 
     return true;
 }
 
-int64_t TcpSocketEngine::nativeNumBytesAvailable(void) const {
+int64_t TcpSocketEngine::nativeNumBytesAvailable() const {
 
     int64_t numBytes(0);
     int64_t dummy(0);

--- a/src/api/internal/io/TcpSocket_p.cpp
+++ b/src/api/internal/io/TcpSocket_p.cpp
@@ -36,7 +36,7 @@ static const int64_t DEFAULT_BUFFER_SIZE64 = DEFAULT_BUFFER_SIZE;
 // TcpSocket implementation
 // --------------------------
 
-TcpSocket::TcpSocket(void)
+TcpSocket::TcpSocket()
     : m_mode(IBamIODevice::NotOpen)
 //    , m_localPort(0)
     , m_remotePort(0)
@@ -47,20 +47,20 @@ TcpSocket::TcpSocket(void)
     , m_state(TcpSocket::UnconnectedState)
 { }
 
-TcpSocket::~TcpSocket(void) {
+TcpSocket::~TcpSocket() {
     if ( m_state == TcpSocket::ConnectedState )
         DisconnectFromHost();
 }
 
-size_t TcpSocket::BufferBytesAvailable(void) const {
+size_t TcpSocket::BufferBytesAvailable() const {
     return m_readBuffer.Size();
 }
 
-bool TcpSocket::CanReadLine(void) const {
+bool TcpSocket::CanReadLine() const {
     return m_readBuffer.CanReadLine();
 }
 
-void TcpSocket::ClearBuffer(void) {
+void TcpSocket::ClearBuffer() {
     m_readBuffer.Clear();
 }
 
@@ -164,7 +164,7 @@ bool TcpSocket::ConnectToHost(const std::string& hostName,
     return ConnectImpl(info, port, mode);
 }
 
-void TcpSocket::DisconnectFromHost(void) {
+void TcpSocket::DisconnectFromHost() {
 
     // close socket engine & delete
     if ( m_state == TcpSocket::ConnectedState )
@@ -182,35 +182,35 @@ void TcpSocket::DisconnectFromHost(void) {
     m_readBuffer.Clear();
 }
 
-TcpSocket::SocketError TcpSocket::GetError(void) const {
+TcpSocket::SocketError TcpSocket::GetError() const {
     return m_error;
 }
 
-std::string TcpSocket::GetErrorString(void) const {
+std::string TcpSocket::GetErrorString() const {
     return m_errorString;
 }
 
-std::string TcpSocket::GetHostName(void) const {
+std::string TcpSocket::GetHostName() const {
     return m_hostName;
 }
 
-//HostAddress TcpSocket::GetLocalAddress(void) const {
+//HostAddress TcpSocket::GetLocalAddress() const {
 //    return m_localAddress;
 //}
 
-//uint16_t TcpSocket::GetLocalPort(void) const {
+//uint16_t TcpSocket::GetLocalPort() const {
 //    return m_localPort;
 //}
 
-HostAddress TcpSocket::GetRemoteAddress(void) const {
+HostAddress TcpSocket::GetRemoteAddress() const {
     return m_remoteAddress;
 }
 
-uint16_t TcpSocket::GetRemotePort(void) const {
+uint16_t TcpSocket::GetRemotePort() const {
     return m_remotePort;
 }
 
-TcpSocket::SocketState TcpSocket::GetState(void) const {
+TcpSocket::SocketState TcpSocket::GetState() const {
     return m_state;
 }
 
@@ -220,7 +220,7 @@ bool TcpSocket::InitializeSocketEngine(HostAddress::NetworkProtocol protocol) {
     return m_engine->Initialize(protocol);
 }
 
-bool TcpSocket::IsConnected(void) const {
+bool TcpSocket::IsConnected() const {
     if ( m_engine == 0 )
         return false;
     return ( m_engine->IsValid() && (m_state == TcpSocket::ConnectedState) );
@@ -258,7 +258,7 @@ int64_t TcpSocket::Read(char* data, const unsigned int numBytes) {
     return static_cast<int64_t>(numBytesRead);
 }
 
-int64_t TcpSocket::ReadFromSocket(void) {
+int64_t TcpSocket::ReadFromSocket() {
 
     // check for any socket engine errors
     if ( !m_engine->IsValid() ) {
@@ -377,7 +377,7 @@ int64_t TcpSocket::ReadLine(char* dest, size_t max) {
     return readSoFar;
 }
 
-void TcpSocket::ResetSocketEngine(void) {
+void TcpSocket::ResetSocketEngine() {
 
     // shut down socket engine
     if ( m_engine ) {
@@ -391,7 +391,7 @@ void TcpSocket::ResetSocketEngine(void) {
     m_cachedSocketDescriptor = -1;
 }
 
-bool TcpSocket::WaitForReadLine(void) {
+bool TcpSocket::WaitForReadLine() {
 
     // wait until we can read a line (will return immediately if already capable)
     while ( !CanReadLine() ) {

--- a/src/api/internal/io/TcpSocket_p.h
+++ b/src/api/internal/io/TcpSocket_p.h
@@ -53,8 +53,8 @@ class TcpSocket {
 
     // ctor & dtor
     public:
-        TcpSocket(void);
-        ~TcpSocket(void);
+        TcpSocket();
+        ~TcpSocket();
 
     // TcpSocket interface
     public:
@@ -66,30 +66,30 @@ class TcpSocket {
         bool ConnectToHost(const std::string& hostName,
                            const std::string& port,    // Connect("host", "80")
                            IBamIODevice::OpenMode mode = IBamIODevice::ReadOnly);
-        void DisconnectFromHost(void);
-        bool IsConnected(void) const;
+        void DisconnectFromHost();
+        bool IsConnected() const;
 
         // I/O methods
-        size_t BufferBytesAvailable(void) const;
-        bool CanReadLine(void) const;
-        void ClearBuffer(void); // force buffer to clear (not a 'flush', just a 'discard')
+        size_t BufferBytesAvailable() const;
+        bool CanReadLine() const;
+        void ClearBuffer(); // force buffer to clear (not a 'flush', just a 'discard')
         int64_t Read(char* data, const unsigned int numBytes);
         std::string ReadLine(int64_t max = 0);
         int64_t ReadLine(char* dest, size_t max);
-        bool WaitForReadLine(void);
+        bool WaitForReadLine();
         int64_t Write(const char* data, const unsigned int numBytes);
 
         // connection values
-        std::string GetHostName(void) const;
-//        HostAddress GetLocalAddress(void) const;
-//        uint16_t    GetLocalPort(void) const;
-        HostAddress GetRemoteAddress(void) const;
-        uint16_t    GetRemotePort(void) const;
+        std::string GetHostName() const;
+//        HostAddress GetLocalAddress() const;
+//        uint16_t    GetLocalPort() const;
+        HostAddress GetRemoteAddress() const;
+        uint16_t    GetRemotePort() const;
 
         // connection status
-        TcpSocket::SocketError GetError(void) const;
-        TcpSocket::SocketState GetState(void) const;
-        std::string GetErrorString(void) const;
+        TcpSocket::SocketError GetError() const;
+        TcpSocket::SocketState GetState() const;
+        std::string GetErrorString() const;
 
     // internal methods
     private:
@@ -97,8 +97,8 @@ class TcpSocket {
                          const std::string& port,
                          IBamIODevice::OpenMode mode);
         bool InitializeSocketEngine(HostAddress::NetworkProtocol protocol);
-        int64_t ReadFromSocket(void);
-        void ResetSocketEngine(void);
+        int64_t ReadFromSocket();
+        void ResetSocketEngine();
 
     // data members
     private:

--- a/src/api/internal/sam/SamFormatParser_p.cpp
+++ b/src/api/internal/sam/SamFormatParser_p.cpp
@@ -22,7 +22,7 @@ SamFormatParser::SamFormatParser(SamHeader& header)
     : m_header(header)
 { }
 
-SamFormatParser::~SamFormatParser(void) { }
+SamFormatParser::~SamFormatParser() { }
 
 void SamFormatParser::Parse(const std::string& headerText) {
 

--- a/src/api/internal/sam/SamFormatParser_p.h
+++ b/src/api/internal/sam/SamFormatParser_p.h
@@ -34,7 +34,7 @@ class SamFormatParser {
     // ctor & dtor
     public:
         SamFormatParser(BamTools::SamHeader& header);
-        ~SamFormatParser(void);
+        ~SamFormatParser();
 
     // parse text & populate header data
     public:

--- a/src/api/internal/sam/SamFormatPrinter_p.cpp
+++ b/src/api/internal/sam/SamFormatPrinter_p.cpp
@@ -34,9 +34,9 @@ SamFormatPrinter::SamFormatPrinter(const SamHeader& header)
     : m_header(header)
 { }
 
-SamFormatPrinter::~SamFormatPrinter(void) { }
+SamFormatPrinter::~SamFormatPrinter() { }
 
-const std::string SamFormatPrinter::ToString(void) const {
+const std::string SamFormatPrinter::ToString() const {
 
     // clear out stream
     std::stringstream out;

--- a/src/api/internal/sam/SamFormatPrinter_p.h
+++ b/src/api/internal/sam/SamFormatPrinter_p.h
@@ -34,11 +34,11 @@ class SamFormatPrinter {
     // ctor & dtor
     public:
         SamFormatPrinter(const BamTools::SamHeader& header);
-        ~SamFormatPrinter(void);
+        ~SamFormatPrinter();
 
     // generates SAM-formatted string from header data
     public:
-        const std::string ToString(void) const;
+        const std::string ToString() const;
 
     // internal methods
     private:

--- a/src/api/internal/sam/SamHeaderValidator_p.cpp
+++ b/src/api/internal/sam/SamHeaderValidator_p.cpp
@@ -71,7 +71,7 @@ SamHeaderValidator::SamHeaderValidator(const SamHeader& header)
     : m_header(header)
 { }
 
-SamHeaderValidator::~SamHeaderValidator(void) { }
+SamHeaderValidator::~SamHeaderValidator() { }
 
 void SamHeaderValidator::AddError(const std::string& message) {
     m_errorMessages.push_back(ERROR_PREFIX + message + NEWLINE);
@@ -119,7 +119,7 @@ void SamHeaderValidator::PrintWarningMessages(std::ostream& stream) {
 }
 
 // entry point for validation
-bool SamHeaderValidator::Validate(void) {
+bool SamHeaderValidator::Validate() {
     bool isValid = true;
     isValid &= ValidateMetadata();
     isValid &= ValidateSequenceDictionary();
@@ -129,7 +129,7 @@ bool SamHeaderValidator::Validate(void) {
 }
 
 // check all SAM header 'metadata'
-bool SamHeaderValidator::ValidateMetadata(void) {
+bool SamHeaderValidator::ValidateMetadata() {
     bool isValid = true;
     isValid &= ValidateVersion();
     isValid &= ValidateSortOrder();
@@ -138,7 +138,7 @@ bool SamHeaderValidator::ValidateMetadata(void) {
 }
 
 // check SAM header version tag
-bool SamHeaderValidator::ValidateVersion(void) {
+bool SamHeaderValidator::ValidateVersion() {
 
     const std::string& version = m_header.Version;
 
@@ -183,7 +183,7 @@ bool SamHeaderValidator::ContainsOnlyDigits(const std::string& s) {
 }
 
 // validate SAM header sort order tag
-bool SamHeaderValidator::ValidateSortOrder(void) {
+bool SamHeaderValidator::ValidateSortOrder() {
 
     const std::string& sortOrder = m_header.SortOrder;
 
@@ -208,7 +208,7 @@ bool SamHeaderValidator::ValidateSortOrder(void) {
 }
 
 // validate SAM header group order tag
-bool SamHeaderValidator::ValidateGroupOrder(void) {
+bool SamHeaderValidator::ValidateGroupOrder() {
 
     const std::string& groupOrder = m_header.GroupOrder;
 
@@ -231,7 +231,7 @@ bool SamHeaderValidator::ValidateGroupOrder(void) {
 }
 
 // validate SAM header sequence dictionary
-bool SamHeaderValidator::ValidateSequenceDictionary(void) {
+bool SamHeaderValidator::ValidateSequenceDictionary() {
 
     bool isValid = true;
 
@@ -252,7 +252,7 @@ bool SamHeaderValidator::ValidateSequenceDictionary(void) {
 }
 
 // make sure all SQ names are unique
-bool SamHeaderValidator::ContainsUniqueSequenceNames(void) {
+bool SamHeaderValidator::ContainsUniqueSequenceNames() {
 
     bool isValid = true;
     std::set<std::string> sequenceNames;
@@ -335,7 +335,7 @@ bool SamHeaderValidator::CheckLengthInRange(const std::string& length) {
 }
 
 // validate SAM header read group dictionary
-bool SamHeaderValidator::ValidateReadGroupDictionary(void) {
+bool SamHeaderValidator::ValidateReadGroupDictionary() {
 
     bool isValid = true;
 
@@ -356,7 +356,7 @@ bool SamHeaderValidator::ValidateReadGroupDictionary(void) {
 }
 
 // make sure RG IDs and platform units are unique
-bool SamHeaderValidator::ContainsUniqueIDsAndPlatformUnits(void) {
+bool SamHeaderValidator::ContainsUniqueIDsAndPlatformUnits() {
 
     bool isValid = true;
     std::set<std::string> readGroupIds;
@@ -455,7 +455,7 @@ bool SamHeaderValidator::CheckSequencingTechnology(const std::string& technology
 }
 
 // validate the SAM header "program chain"
-bool SamHeaderValidator::ValidateProgramChain(void) {
+bool SamHeaderValidator::ValidateProgramChain() {
     bool isValid = true;
     isValid &= ContainsUniqueProgramIds();
     isValid &= ValidatePreviousProgramIds();
@@ -463,7 +463,7 @@ bool SamHeaderValidator::ValidateProgramChain(void) {
 }
 
 // make sure all PG IDs are unique
-bool SamHeaderValidator::ContainsUniqueProgramIds(void) {
+bool SamHeaderValidator::ContainsUniqueProgramIds() {
 
     bool isValid = true;
     std::set<std::string> programIds;
@@ -495,7 +495,7 @@ bool SamHeaderValidator::ContainsUniqueProgramIds(void) {
 }
 
 // make sure that any PP tags present point to existing @PG IDs
-bool SamHeaderValidator::ValidatePreviousProgramIds(void) {
+bool SamHeaderValidator::ValidatePreviousProgramIds() {
 
     bool isValid = true;
 

--- a/src/api/internal/sam/SamHeaderValidator_p.h
+++ b/src/api/internal/sam/SamHeaderValidator_p.h
@@ -37,7 +37,7 @@ class SamHeaderValidator {
     // ctor & dtor
     public:
         SamHeaderValidator(const SamHeader& header);
-        ~SamHeaderValidator(void);
+        ~SamHeaderValidator();
 
     // SamHeaderValidator interface
     public:
@@ -46,36 +46,36 @@ class SamHeaderValidator {
         void PrintMessages(std::ostream& stream);
 
         // validates SamHeader data, returns true/false accordingly
-        bool Validate(void);
+        bool Validate();
 
     // internal methods
     private:
 
         // validate header metadata
-        bool ValidateMetadata(void);
-        bool ValidateVersion(void);
+        bool ValidateMetadata();
+        bool ValidateVersion();
         bool ContainsOnlyDigits(const std::string& s);
-        bool ValidateSortOrder(void);
-        bool ValidateGroupOrder(void);
+        bool ValidateSortOrder();
+        bool ValidateGroupOrder();
 
         // validate sequence dictionary
-        bool ValidateSequenceDictionary(void);
-        bool ContainsUniqueSequenceNames(void);
+        bool ValidateSequenceDictionary();
+        bool ContainsUniqueSequenceNames();
         bool CheckNameFormat(const std::string& name);
         bool ValidateSequence(const SamSequence& seq);
         bool CheckLengthInRange(const std::string& length);
 
         // validate read group dictionary
-        bool ValidateReadGroupDictionary(void);
-        bool ContainsUniqueIDsAndPlatformUnits(void);
+        bool ValidateReadGroupDictionary();
+        bool ContainsUniqueIDsAndPlatformUnits();
         bool ValidateReadGroup(const SamReadGroup& rg);
         bool CheckReadGroupID(const std::string& id);
         bool CheckSequencingTechnology(const std::string& technology);
 
         // validate program data
-        bool ValidateProgramChain(void);
-        bool ContainsUniqueProgramIds(void);
-        bool ValidatePreviousProgramIds(void);
+        bool ValidateProgramChain();
+        bool ContainsUniqueProgramIds();
+        bool ValidatePreviousProgramIds();
 
         // error reporting
         void AddError(const std::string& message);

--- a/src/api/internal/sam/SamHeaderVersion_p.h
+++ b/src/api/internal/sam/SamHeaderVersion_p.h
@@ -31,7 +31,7 @@ class SamHeaderVersion {
 
     // ctors & dtor
     public:
-        SamHeaderVersion(void)
+        SamHeaderVersion()
             : m_majorVersion(0)
             , m_minorVersion(0)
         { }
@@ -48,18 +48,18 @@ class SamHeaderVersion {
             , m_minorVersion(minor)
         { }
 
-        ~SamHeaderVersion(void) {
+        ~SamHeaderVersion() {
             m_majorVersion = 0;
             m_minorVersion = 0;
         }
 
     // acess data
     public:
-        unsigned int MajorVersion(void) const { return m_majorVersion; }
-        unsigned int MinorVersion(void) const { return m_minorVersion; }
+        unsigned int MajorVersion() const { return m_majorVersion; }
+        unsigned int MinorVersion() const { return m_minorVersion; }
 
         void SetVersion(const std::string& version);
-        std::string ToString(void) const;
+        std::string ToString() const;
 
     // data members
     private:
@@ -103,7 +103,7 @@ void SamHeaderVersion::SetVersion(const std::string& version) {
 // -----------------------------------------------------
 // printing
 
-inline std::string SamHeaderVersion::ToString(void) const {
+inline std::string SamHeaderVersion::ToString() const {
     std::stringstream version;
     version << m_majorVersion << Constants::SAM_PERIOD << m_minorVersion;
     return version.str();

--- a/src/api/internal/utils/BamException_p.h
+++ b/src/api/internal/utils/BamException_p.h
@@ -34,9 +34,9 @@ class BamException : public std::exception {
             , m_errorString(where + SEPARATOR + message)
         { }
 
-        inline ~BamException(void) throw() { }
+        inline ~BamException() throw() { }
 
-        inline const char* what(void) const throw() {
+        inline const char* what() const throw() {
             return m_errorString.c_str();
         }
 

--- a/src/shared/bamtools_global.h
+++ b/src/shared/bamtools_global.h
@@ -76,7 +76,7 @@
 #endif // BAMTOOLS_TYPES
 
 //! \internal
-inline void bamtools_noop(void) { }
+inline void bamtools_noop() { }
 
 /*! \brief Assert definitions
     \internal

--- a/src/toolkit/bamtools.cpp
+++ b/src/toolkit/bamtools.cpp
@@ -125,7 +125,7 @@ int Help(int argc, char* argv[]) {
 }
 
 // print version info
-int Version(void) {
+int Version() {
 
     std::stringstream versionStream;
     versionStream << BAMTOOLS_VERSION_MAJOR << "."

--- a/src/toolkit/bamtools_convert.cpp
+++ b/src/toolkit/bamtools_convert.cpp
@@ -51,7 +51,7 @@ class ConvertPileupFormatVisitor : public PileupVisitor {
                                    const std::string& fastaFilename,
                                    const bool isPrintingMapQualities,
                                    std::ostream* out);
-        ~ConvertPileupFormatVisitor(void);
+        ~ConvertPileupFormatVisitor();
 
     // PileupVisitor interface implementation
     public:
@@ -96,7 +96,7 @@ struct ConvertTool::ConvertSettings {
     std::string FastaFilename;
 
     // constructor
-    ConvertSettings(void)
+    ConvertSettings()
         : HasInput(false)
         , HasInputFilelist(false)
         , HasOutput(false)
@@ -122,11 +122,11 @@ struct ConvertTool::ConvertToolPrivate {
             , m_out(std::cout.rdbuf())
         { }
 
-        ~ConvertToolPrivate(void) { }
+        ~ConvertToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
@@ -147,7 +147,7 @@ struct ConvertTool::ConvertToolPrivate {
         std::ostream m_out;
 };
 
-bool ConvertTool::ConvertToolPrivate::Run(void) {
+bool ConvertTool::ConvertToolPrivate::Run() {
 
     // ------------------------------------
     // initialize conversion input/output
@@ -713,7 +713,7 @@ bool ConvertTool::ConvertToolPrivate::RunPileupConversion(BamMultiReader* reader
 // ---------------------------------------------
 // ConvertTool implementation
 
-ConvertTool::ConvertTool(void)
+ConvertTool::ConvertTool()
     : AbstractTool()
     , m_settings(new ConvertSettings)
     , m_impl(0)
@@ -738,7 +738,7 @@ ConvertTool::ConvertTool(void)
     Options::AddOption("-noheader", "omit the SAM header from output", m_settings->IsOmittingSamHeader, SamOpts);
 }
 
-ConvertTool::~ConvertTool(void) {
+ConvertTool::~ConvertTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -747,7 +747,7 @@ ConvertTool::~ConvertTool(void) {
     m_impl = 0;
 }
 
-int ConvertTool::Help(void) {
+int ConvertTool::Help() {
     Options::DisplayHelp();
     return 0;
 }
@@ -794,7 +794,7 @@ ConvertPileupFormatVisitor::ConvertPileupFormatVisitor(const RefVector& referenc
     }
 }
 
-ConvertPileupFormatVisitor::~ConvertPileupFormatVisitor(void) {
+ConvertPileupFormatVisitor::~ConvertPileupFormatVisitor() {
     // be sure to close Fasta reader
     if ( m_hasFasta ) {
         m_fasta.Close();

--- a/src/toolkit/bamtools_convert.h
+++ b/src/toolkit/bamtools_convert.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class ConvertTool : public AbstractTool {
 
     public:
-        ConvertTool(void);
-        ~ConvertTool(void);
+        ConvertTool();
+        ~ConvertTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_count.cpp
+++ b/src/toolkit/bamtools_count.cpp
@@ -36,7 +36,7 @@ struct CountTool::CountSettings {
     std::string Region;
 
     // constructor
-    CountSettings(void)
+    CountSettings()
         : HasInput(false)
         , HasInputFilelist(false)
         , HasRegion(false)
@@ -54,18 +54,18 @@ struct CountTool::CountToolPrivate {
             : m_settings(settings)
         { }
 
-        ~CountToolPrivate(void) { }
+        ~CountToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
         CountTool::CountSettings* m_settings;
 };
 
-bool CountTool::CountToolPrivate::Run(void) {
+bool CountTool::CountToolPrivate::Run() {
 
     // set to default input if none provided
     if ( !m_settings->HasInput && !m_settings->HasInputFilelist )
@@ -161,7 +161,7 @@ bool CountTool::CountToolPrivate::Run(void) {
 // ---------------------------------------------
 // CountTool implementation
 
-CountTool::CountTool(void)
+CountTool::CountTool()
     : AbstractTool()
     , m_settings(new CountSettings)
     , m_impl(0)
@@ -179,7 +179,7 @@ CountTool::CountTool(void)
                             "", m_settings->HasRegion, m_settings->Region, IO_Opts);
 }
 
-CountTool::~CountTool(void) {
+CountTool::~CountTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -188,7 +188,7 @@ CountTool::~CountTool(void) {
     m_impl = 0;
 }
 
-int CountTool::Help(void) {
+int CountTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_count.h
+++ b/src/toolkit/bamtools_count.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class CountTool : public AbstractTool {
 
     public:
-        CountTool(void);
-        ~CountTool(void);
+        CountTool();
+        ~CountTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_coverage.cpp
+++ b/src/toolkit/bamtools_coverage.cpp
@@ -32,7 +32,7 @@ class CoverageVisitor : public PileupVisitor {
             , m_references(references)
             , m_out(out)
         { }
-        ~CoverageVisitor(void) { }
+        ~CoverageVisitor() { }
 
     // PileupVisitor interface implementation
     public:
@@ -64,7 +64,7 @@ struct CoverageTool::CoverageSettings {
     std::string OutputFilename;
 
     // constructor
-    CoverageSettings(void)
+    CoverageSettings()
         : HasInputFile(false)
         , HasOutputFile(false)
         , InputBamFilename(Options::StandardIn())
@@ -84,11 +84,11 @@ struct CoverageTool::CoverageToolPrivate {
             , m_out(std::cout.rdbuf())
         { }
 
-        ~CoverageToolPrivate(void) { }
+        ~CoverageToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
@@ -97,7 +97,7 @@ struct CoverageTool::CoverageToolPrivate {
         RefVector m_references;
 };
 
-bool CoverageTool::CoverageToolPrivate::Run(void) {
+bool CoverageTool::CoverageToolPrivate::Run() {
 
     // if output filename given
     std::ofstream outFile;
@@ -152,7 +152,7 @@ bool CoverageTool::CoverageToolPrivate::Run(void) {
 // ---------------------------------------------
 // CoverageTool implementation
 
-CoverageTool::CoverageTool(void)
+CoverageTool::CoverageTool()
     : AbstractTool()
     , m_settings(new CoverageSettings)
     , m_impl(0)
@@ -166,7 +166,7 @@ CoverageTool::CoverageTool(void)
     Options::AddValueOption("-out", "filename",     "the output file",    "", m_settings->HasOutputFile, m_settings->OutputFilename,   IO_Opts, Options::StandardOut());
 }
 
-CoverageTool::~CoverageTool(void) {
+CoverageTool::~CoverageTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -175,7 +175,7 @@ CoverageTool::~CoverageTool(void) {
     m_impl = 0;
 }
 
-int CoverageTool::Help(void) {
+int CoverageTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_coverage.h
+++ b/src/toolkit/bamtools_coverage.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class CoverageTool : public AbstractTool {
 
     public:
-        CoverageTool(void);
-        ~CoverageTool(void);
+        CoverageTool();
+        ~CoverageTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_filter.cpp
+++ b/src/toolkit/bamtools_filter.cpp
@@ -319,7 +319,7 @@ struct FilterTool::FilterSettings {
     // ---------------------------------
     // constructor
 
-    FilterSettings(void)
+    FilterSettings()
         : HasInput(false)
         , HasInputFilelist(false)
         , HasOutput(false)
@@ -369,22 +369,22 @@ class FilterTool::FilterToolPrivate {
     // ctor & dtor
     public:
         FilterToolPrivate(FilterTool::FilterSettings* settings);
-        ~FilterToolPrivate(void);
+        ~FilterToolPrivate();
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
         bool AddPropertyTokensToFilter(const std::string& filterName, const std::map<std::string, std::string>& propertyTokens);
         bool CheckAlignment(const BamAlignment& al);
-        const std::string GetScriptContents(void);
-        void InitProperties(void);
-        bool ParseCommandLine(void);
+        const std::string GetScriptContents();
+        void InitProperties();
+        bool ParseCommandLine();
         bool ParseFilterObject(const std::string& filterName, const Json::Value& filterObject);
-        bool ParseScript(void);
-        bool SetupFilters(void);
+        bool ParseScript();
+        bool SetupFilters();
 
     // data members
     private:
@@ -402,7 +402,7 @@ FilterTool::FilterToolPrivate::FilterToolPrivate(FilterTool::FilterSettings* set
 { }
 
 // destructor
-FilterTool::FilterToolPrivate::~FilterToolPrivate(void) { }
+FilterTool::FilterToolPrivate::~FilterToolPrivate() { }
 
 bool FilterTool::FilterToolPrivate::AddPropertyTokensToFilter(const std::string& filterName,
                                                               const std::map<std::string,
@@ -503,7 +503,7 @@ bool FilterTool::FilterToolPrivate::CheckAlignment(const BamAlignment& al) {
     return m_filterEngine.check(al);
 }
 
-const std::string FilterTool::FilterToolPrivate::GetScriptContents(void) {
+const std::string FilterTool::FilterToolPrivate::GetScriptContents() {
 
     // open script for reading
     FILE* inFile = fopen(m_settings->ScriptFilename.c_str(), "rb");
@@ -540,7 +540,7 @@ const std::string FilterTool::FilterToolPrivate::GetScriptContents(void) {
     return docStream.str();
 }
 
-void FilterTool::FilterToolPrivate::InitProperties(void) {
+void FilterTool::FilterToolPrivate::InitProperties() {
 
     // store property names in vector
     m_propertyNames.push_back(ALIGNMENTFLAG_PROPERTY);
@@ -575,7 +575,7 @@ void FilterTool::FilterToolPrivate::InitProperties(void) {
         m_filterEngine.addProperty((*propertyNameIter));
 }
 
-bool FilterTool::FilterToolPrivate::ParseCommandLine(void) {
+bool FilterTool::FilterToolPrivate::ParseCommandLine() {
 
     // add a rule set to filter engine
     const std::string CMD = "COMMAND_LINE";
@@ -635,7 +635,7 @@ bool FilterTool::FilterToolPrivate::ParseFilterObject(const std::string& filterN
     return AddPropertyTokensToFilter(filterName, propertyTokens);
 }
 
-bool FilterTool::FilterToolPrivate::ParseScript(void) {
+bool FilterTool::FilterToolPrivate::ParseScript() {
 
     // read in script contents from file
     const std::string document = GetScriptContents();
@@ -706,7 +706,7 @@ bool FilterTool::FilterToolPrivate::ParseScript(void) {
     return success;
 }
 
-bool FilterTool::FilterToolPrivate::Run(void) {
+bool FilterTool::FilterToolPrivate::Run() {
 
     // set to default input if none provided
     if ( !m_settings->HasInput && !m_settings->HasInputFilelist )
@@ -822,7 +822,7 @@ bool FilterTool::FilterToolPrivate::Run(void) {
     return true;
 }
 
-bool FilterTool::FilterToolPrivate::SetupFilters(void) {
+bool FilterTool::FilterToolPrivate::SetupFilters() {
 
     // set up filter engine with supported properties
     InitProperties();
@@ -838,7 +838,7 @@ bool FilterTool::FilterToolPrivate::SetupFilters(void) {
 // ---------------------------------------------
 // FilterTool implementation
 
-FilterTool::FilterTool(void)
+FilterTool::FilterTool()
     : AbstractTool()
     , m_settings(new FilterSettings)
     , m_impl(0)
@@ -927,7 +927,7 @@ FilterTool::FilterTool(void)
     Options::AddValueOption("-isSingleton",         boolArg, isSingletonDesc,   "", m_settings->HasIsSingletonFilter,         m_settings->IsSingletonFilter,         AlignmentFlagOpts, TRUE_STR);
 }
 
-FilterTool::~FilterTool(void) {
+FilterTool::~FilterTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -936,7 +936,7 @@ FilterTool::~FilterTool(void) {
     m_impl = 0;
 }
 
-int FilterTool::Help(void) {
+int FilterTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_filter.h
+++ b/src/toolkit/bamtools_filter.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class FilterTool : public AbstractTool {
 
     public:
-        FilterTool(void);
-        ~FilterTool(void);
+        FilterTool();
+        ~FilterTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_header.cpp
+++ b/src/toolkit/bamtools_header.cpp
@@ -33,7 +33,7 @@ struct HeaderTool::HeaderSettings {
     std::string InputFilelist;
 
     // constructor
-    HeaderSettings(void)
+    HeaderSettings()
         : HasInput(false)
         , HasInputFilelist(false)
     { }
@@ -47,18 +47,18 @@ struct HeaderTool::HeaderToolPrivate {
             : m_settings(settings)
         { }
 
-        ~HeaderToolPrivate(void) { }
+        ~HeaderToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
         HeaderTool::HeaderSettings* m_settings;
 };
 
-bool HeaderTool::HeaderToolPrivate::Run(void) {
+bool HeaderTool::HeaderToolPrivate::Run() {
 
     // set to default input if none provided
     if ( !m_settings->HasInput && !m_settings->HasInputFilelist )
@@ -96,7 +96,7 @@ bool HeaderTool::HeaderToolPrivate::Run(void) {
 // ---------------------------------------------
 // HeaderTool implementation
 
-HeaderTool::HeaderTool(void)
+HeaderTool::HeaderTool()
     : AbstractTool()
     , m_settings(new HeaderSettings)
     , m_impl(0)
@@ -110,7 +110,7 @@ HeaderTool::HeaderTool(void)
     Options::AddValueOption("-list", "filename", "the input BAM file list, one line per file", "", m_settings->HasInputFilelist,  m_settings->InputFilelist, IO_Opts);
 }
 
-HeaderTool::~HeaderTool(void) {
+HeaderTool::~HeaderTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -119,7 +119,7 @@ HeaderTool::~HeaderTool(void) {
     m_impl = 0;
 }
 
-int HeaderTool::Help(void) {
+int HeaderTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_header.h
+++ b/src/toolkit/bamtools_header.h
@@ -18,11 +18,11 @@ namespace BamTools {
 class HeaderTool : public AbstractTool {
 
     public:
-        HeaderTool(void);
-        ~HeaderTool(void);
+        HeaderTool();
+        ~HeaderTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_index.cpp
+++ b/src/toolkit/bamtools_index.cpp
@@ -29,7 +29,7 @@ struct IndexTool::IndexSettings {
     std::string InputBamFilename;
 
     // constructor
-    IndexSettings(void)
+    IndexSettings()
         : HasInputBamFilename(false)
         , IsUsingBamtoolsIndex(false)
         , InputBamFilename(Options::StandardIn())
@@ -47,18 +47,18 @@ struct IndexTool::IndexToolPrivate {
             : m_settings(settings)
         { }
 
-        ~IndexToolPrivate(void) { }
+        ~IndexToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
         IndexTool::IndexSettings* m_settings;
 };
 
-bool IndexTool::IndexToolPrivate::Run(void) {
+bool IndexTool::IndexToolPrivate::Run() {
 
     // open our BAM reader
     BamReader reader;
@@ -81,7 +81,7 @@ bool IndexTool::IndexToolPrivate::Run(void) {
 // ---------------------------------------------
 // IndexTool implementation
 
-IndexTool::IndexTool(void)
+IndexTool::IndexTool()
     : AbstractTool()
     , m_settings(new IndexSettings)
     , m_impl(0)
@@ -95,7 +95,7 @@ IndexTool::IndexTool(void)
     Options::AddOption("-bti", "create (non-standard) BamTools index file (*.bti). Default behavior is to create standard BAM index (*.bai)", m_settings->IsUsingBamtoolsIndex, IO_Opts);
 }
 
-IndexTool::~IndexTool(void) {
+IndexTool::~IndexTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -104,7 +104,7 @@ IndexTool::~IndexTool(void) {
     m_impl = 0;
 }
 
-int IndexTool::Help(void) {
+int IndexTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_index.h
+++ b/src/toolkit/bamtools_index.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class IndexTool : public AbstractTool {
 
     public:
-        IndexTool(void);
-        ~IndexTool(void);
+        IndexTool();
+        ~IndexTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_merge.cpp
+++ b/src/toolkit/bamtools_merge.cpp
@@ -41,7 +41,7 @@ struct MergeTool::MergeSettings {
     std::string Region;
 
     // constructor
-    MergeSettings(void)
+    MergeSettings()
         : HasInput(false)
         , HasInputFilelist(false)
         , HasOutput(false)
@@ -62,18 +62,18 @@ struct MergeTool::MergeToolPrivate {
             : m_settings(settings)
         { }
 
-        ~MergeToolPrivate(void) { }
+        ~MergeToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
         MergeTool::MergeSettings* m_settings;
 };
 
-bool MergeTool::MergeToolPrivate::Run(void) {
+bool MergeTool::MergeToolPrivate::Run() {
 
     // set to default input if none provided
     if ( !m_settings->HasInput && !m_settings->HasInputFilelist )
@@ -192,7 +192,7 @@ bool MergeTool::MergeToolPrivate::Run(void) {
 // ---------------------------------------------
 // MergeTool implementation
 
-MergeTool::MergeTool(void)
+MergeTool::MergeTool()
     : AbstractTool()
     , m_settings(new MergeSettings)
     , m_impl(0)
@@ -210,7 +210,7 @@ MergeTool::MergeTool(void)
     Options::AddValueOption("-region", "REGION", "genomic region. See README for more details", "", m_settings->HasRegion, m_settings->Region, IO_Opts);
 }
 
-MergeTool::~MergeTool(void) {
+MergeTool::~MergeTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -219,7 +219,7 @@ MergeTool::~MergeTool(void) {
     m_impl = 0;
 }
 
-int MergeTool::Help(void) {
+int MergeTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_merge.h
+++ b/src/toolkit/bamtools_merge.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class MergeTool : public AbstractTool {
 
     public:
-        MergeTool(void);
-        ~MergeTool(void);
+        MergeTool();
+        ~MergeTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_random.cpp
+++ b/src/toolkit/bamtools_random.cpp
@@ -58,7 +58,7 @@ struct RandomTool::RandomSettings {
     std::string Region;
 
     // constructor
-    RandomSettings(void)
+    RandomSettings()
         : HasAlignmentCount(false)
         , HasInput(false)
         , HasInputFilelist(false)
@@ -83,18 +83,18 @@ struct RandomTool::RandomToolPrivate {
             : m_settings(settings)
         { }
 
-        ~RandomToolPrivate(void) { }
+        ~RandomToolPrivate() { }
 
     // interface
     public:
-        bool Run(void);
+        bool Run();
 
     // data members
     private:
         RandomTool::RandomSettings* m_settings;
 };
 
-bool RandomTool::RandomToolPrivate::Run(void) {
+bool RandomTool::RandomToolPrivate::Run() {
 
     // set to default stdin if no input files provided
     if ( !m_settings->HasInput && !m_settings->HasInputFilelist )
@@ -230,7 +230,7 @@ bool RandomTool::RandomToolPrivate::Run(void) {
 // ---------------------------------------------
 // RandomTool implementation
 
-RandomTool::RandomTool(void)
+RandomTool::RandomTool()
     : AbstractTool()
     , m_settings(new RandomSettings)
     , m_impl(0)
@@ -254,7 +254,7 @@ RandomTool::RandomTool(void)
                             m_settings->HasRandomNumberSeed, m_settings->RandomNumberSeed, SettingsOpts);
 }
 
-RandomTool::~RandomTool(void) {
+RandomTool::~RandomTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -263,7 +263,7 @@ RandomTool::~RandomTool(void) {
     m_impl = 0;
 }
 
-int RandomTool::Help(void) {
+int RandomTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_random.h
+++ b/src/toolkit/bamtools_random.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class RandomTool : public AbstractTool {
 
     public:
-        RandomTool(void);
-        ~RandomTool(void);
+        RandomTool();
+        ~RandomTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_resolve.cpp
+++ b/src/toolkit/bamtools_resolve.cpp
@@ -109,13 +109,13 @@ struct ModelType {
     }
 
     // convenience access to internal fragment lengths vector
-    std::vector<int32_t>::iterator begin(void) { return FragmentLengths.begin(); }
-    std::vector<int32_t>::const_iterator begin(void) const { return FragmentLengths.begin(); }
-    void clear(void) { FragmentLengths.clear(); }
-    std::vector<int32_t>::iterator end(void) { return FragmentLengths.end(); }
-    std::vector<int32_t>::const_iterator end(void) const { return FragmentLengths.end(); }
+    std::vector<int32_t>::iterator begin() { return FragmentLengths.begin(); }
+    std::vector<int32_t>::const_iterator begin() const { return FragmentLengths.begin(); }
+    void clear() { FragmentLengths.clear(); }
+    std::vector<int32_t>::iterator end() { return FragmentLengths.end(); }
+    std::vector<int32_t>::const_iterator end() const { return FragmentLengths.end(); }
     void push_back(const int32_t& x) { FragmentLengths.push_back(x); }
-    size_t size(void) const { return FragmentLengths.size(); }
+    size_t size() const { return FragmentLengths.size(); }
 
     // constants
     static const uint16_t DUMMY_ID;
@@ -169,7 +169,7 @@ struct ReadGroupResolver {
     std::map<std::string, bool> ReadNames;
 
     // ctor
-    ReadGroupResolver(void);
+    ReadGroupResolver();
 
     // resolving methods
     bool IsValidInsertSize(const BamAlignment& al) const;
@@ -188,7 +188,7 @@ struct ReadGroupResolver {
 double ReadGroupResolver::ConfidenceInterval   = DEFAULT_CONFIDENCE_INTERVAL;
 double ReadGroupResolver::UnusedModelThreshold = DEFAULT_UNUSEDMODEL_THRESHOLD;
 
-ReadGroupResolver::ReadGroupResolver(void)
+ReadGroupResolver::ReadGroupResolver()
     : MinFragmentLength(0)
     , MedianFragmentLength(0)
     , MaxFragmentLength(0)
@@ -327,7 +327,7 @@ struct ResolveTool::ResolveSettings {
     double   UnusedModelThreshold;
 
     // constructor
-    ResolveSettings(void)
+    ResolveSettings()
         : IsMakeStats(false)
         , IsMarkPairs(false)
         , IsTwoPass(false)
@@ -355,12 +355,12 @@ struct ResolveTool::ResolveSettings {
 struct ResolveTool::ReadNamesFileReader {
 
     // ctor & dtor
-    ReadNamesFileReader(void) { }
-    ~ReadNamesFileReader(void) { Close(); }
+    ReadNamesFileReader() { }
+    ~ReadNamesFileReader() { Close(); }
 
     // main reader interface
     public:
-        void Close(void);
+        void Close();
         bool Open(const std::string& filename);
         bool Read(std::map<std::string, ReadGroupResolver>& readGroups);
 
@@ -369,7 +369,7 @@ struct ResolveTool::ReadNamesFileReader {
         std::ifstream m_stream;
 };
 
-void ResolveTool::ReadNamesFileReader::Close(void) {
+void ResolveTool::ReadNamesFileReader::Close() {
     if ( m_stream.is_open() )
         m_stream.close();
 }
@@ -422,12 +422,12 @@ bool ResolveTool::ReadNamesFileReader::Read(std::map<std::string, ReadGroupResol
 struct ResolveTool::ReadNamesFileWriter {
 
     // ctor & dtor
-    ReadNamesFileWriter(void) { }
-    ~ReadNamesFileWriter(void) { Close(); }
+    ReadNamesFileWriter() { }
+    ~ReadNamesFileWriter() { Close(); }
 
     // main reader interface
     public:
-        void Close(void);
+        void Close();
         bool Open(const std::string& filename);
         void Write(const std::string& readGroupName, const std::string& readName);
 
@@ -436,7 +436,7 @@ struct ResolveTool::ReadNamesFileWriter {
         std::ofstream m_stream;
 };
 
-void ResolveTool::ReadNamesFileWriter::Close(void) {
+void ResolveTool::ReadNamesFileWriter::Close() {
     if ( m_stream.is_open() )
         m_stream.close();
 }
@@ -464,12 +464,12 @@ struct ResolveTool::StatsFileReader {
 
     // ctor & dtor
     public:
-        StatsFileReader(void) { }
-        ~StatsFileReader(void) { Close(); }
+        StatsFileReader() { }
+        ~StatsFileReader() { Close(); }
 
     // main reader interface
     public:
-        void Close(void);
+        void Close();
         bool Open(const std::string& filename);
         bool Read(ResolveTool::ResolveSettings* settings,
                   std::map<std::string, ReadGroupResolver>& readGroups);
@@ -481,7 +481,7 @@ struct ResolveTool::StatsFileReader {
         bool ParseInputLine(const std::string& line);
         bool ParseOptionLine(const std::string& line, ResolveTool::ResolveSettings* settings);
         bool ParseReadGroupLine(const std::string& line, std::map<std::string, ReadGroupResolver>& readGroups);
-        std::string SkipCommentsAndWhitespace(void);
+        std::string SkipCommentsAndWhitespace();
 
     // data members
     private:
@@ -493,7 +493,7 @@ struct ResolveTool::StatsFileReader {
                    , InReadGroups };
 };
 
-void ResolveTool::StatsFileReader::Close(void) {
+void ResolveTool::StatsFileReader::Close() {
     if ( m_stream.is_open() )
         m_stream.close();
 }
@@ -661,7 +661,7 @@ bool ResolveTool::StatsFileReader::Read(ResolveTool::ResolveSettings* settings,
     return true;
 }
 
-std::string ResolveTool::StatsFileReader::SkipCommentsAndWhitespace(void) {
+std::string ResolveTool::StatsFileReader::SkipCommentsAndWhitespace() {
     std::string line;
     do {
         if ( m_stream.eof() )
@@ -678,19 +678,19 @@ struct ResolveTool::StatsFileWriter {
 
     // ctor & dtor
     public:
-        StatsFileWriter(void) { }
-        ~StatsFileWriter(void) { Close(); }
+        StatsFileWriter() { }
+        ~StatsFileWriter() { Close(); }
 
     // main reader interface
     public:
-        void Close(void);
+        void Close();
         bool Open(const std::string& filename);
         bool Write(ResolveTool::ResolveSettings* settings,
                    const std::map<std::string, ReadGroupResolver>& readGroups);
 
     // internal methods
     private:
-        void WriteHeader(void);
+        void WriteHeader();
         void WriteInput(ResolveTool::ResolveSettings* settings);
         void WriteOptions(ResolveTool::ResolveSettings* settings);
         void WriteReadGroups(const std::map<std::string, ReadGroupResolver>& readGroups);
@@ -700,7 +700,7 @@ struct ResolveTool::StatsFileWriter {
         std::ofstream m_stream;
 };
 
-void ResolveTool::StatsFileWriter::Close(void) {
+void ResolveTool::StatsFileWriter::Close() {
     if ( m_stream.is_open() )
         m_stream.close();
 }
@@ -732,7 +732,7 @@ bool ResolveTool::StatsFileWriter::Write(ResolveTool::ResolveSettings* settings,
     return true;
 }
 
-void ResolveTool::StatsFileWriter::WriteHeader(void) {
+void ResolveTool::StatsFileWriter::WriteHeader() {
 
     // stringify current bamtools version
     std::stringstream versionStream;
@@ -823,21 +823,21 @@ struct ResolveTool::ResolveToolPrivate {
         ResolveToolPrivate(ResolveTool::ResolveSettings* settings)
             : m_settings(settings)
         { }
-        ~ResolveToolPrivate(void) { }
+        ~ResolveToolPrivate() { }
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
         bool CheckSettings(std::vector<std::string>& errors);
-        bool MakeStats(void);
+        bool MakeStats();
         void ParseHeader(const SamHeader& header);
-        bool ReadStatsFile(void);
+        bool ReadStatsFile();
         void ResolveAlignment(BamAlignment& al);
-        bool ResolvePairs(void);
-        bool WriteStatsFile(void);
+        bool ResolvePairs();
+        bool WriteStatsFile();
 
     // data members
     private:
@@ -928,7 +928,7 @@ bool ResolveTool::ResolveToolPrivate::CheckSettings(std::vector<std::string>& er
     return ( errors.empty() );
 }
 
-bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
+bool ResolveTool::ResolveToolPrivate::MakeStats() {
 
     // pull resolver settings from command-line settings
     ReadGroupResolver::SetConfidenceInterval(m_settings->ConfidenceInterval);
@@ -1049,7 +1049,7 @@ void ResolveTool::ResolveToolPrivate::ParseHeader(const SamHeader& header) {
     }
 }
 
-bool ResolveTool::ResolveToolPrivate::ReadStatsFile(void) {
+bool ResolveTool::ResolveToolPrivate::ReadStatsFile() {
 
     // skip if no filename provided
     if ( m_settings->StatsFilename.empty() )
@@ -1121,7 +1121,7 @@ void ResolveTool::ResolveToolPrivate::ResolveAlignment(BamAlignment& al) {
     al.SetIsProperPair(true);
 }
 
-bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
+bool ResolveTool::ResolveToolPrivate::ResolvePairs() {
 
     // open file containing read names of candidate proper pairs
     ResolveTool::ReadNamesFileReader readNamesReader;
@@ -1188,7 +1188,7 @@ bool ResolveTool::ResolveToolPrivate::ResolvePairs(void) {
     return true;
 }
 
-bool ResolveTool::ResolveToolPrivate::Run(void) {
+bool ResolveTool::ResolveToolPrivate::Run() {
 
     // verify that command line settings are acceptable
     std::vector<std::string> errors;
@@ -1274,7 +1274,7 @@ bool ResolveTool::ResolveToolPrivate::Run(void) {
     return true;
 }
 
-bool ResolveTool::ResolveToolPrivate::WriteStatsFile(void) {
+bool ResolveTool::ResolveToolPrivate::WriteStatsFile() {
 
     // skip if no filename provided
     if ( m_settings->StatsFilename.empty() )
@@ -1302,7 +1302,7 @@ bool ResolveTool::ResolveToolPrivate::WriteStatsFile(void) {
 // --------------------------------------------------------------------------
 // ResolveTool implementation
 
-ResolveTool::ResolveTool(void)
+ResolveTool::ResolveTool()
     : AbstractTool()
     , m_settings(new ResolveSettings)
     , m_impl(0)
@@ -1381,7 +1381,7 @@ ResolveTool::ResolveTool(void)
     Options::AddOption("-force", forceMarkDescription, m_settings->HasForceMarkReadGroups, MarkPairsOpts);
 }
 
-ResolveTool::~ResolveTool(void) {
+ResolveTool::~ResolveTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -1390,7 +1390,7 @@ ResolveTool::~ResolveTool(void) {
     m_impl = 0;
 }
 
-int ResolveTool::Help(void) {
+int ResolveTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_resolve.h
+++ b/src/toolkit/bamtools_resolve.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class ResolveTool : public AbstractTool {
 
     public:
-        ResolveTool(void);
-        ~ResolveTool(void);
+        ResolveTool();
+        ~ResolveTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_revert.cpp
+++ b/src/toolkit/bamtools_revert.cpp
@@ -41,7 +41,7 @@ struct RevertTool::RevertSettings {
     std::string OutputFilename;
 
     // constructor
-    RevertSettings(void)
+    RevertSettings()
         : HasInput(false)
         , HasOutput(false)
         , IsForceCompression(false)
@@ -62,11 +62,11 @@ struct RevertTool::RevertToolPrivate {
         RevertToolPrivate(RevertTool::RevertSettings* settings)
             : m_settings(settings)
         { }
-        ~RevertToolPrivate(void) { }
+        ~RevertToolPrivate() { }
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
@@ -98,7 +98,7 @@ void RevertTool::RevertToolPrivate::RevertAlignment(BamAlignment& al) {
         al.SetIsDuplicate(false);
 }
 
-bool RevertTool::RevertToolPrivate::Run(void) {
+bool RevertTool::RevertToolPrivate::Run() {
 
     // opens the BAM file without checking for indexes
     BamReader reader;
@@ -144,7 +144,7 @@ bool RevertTool::RevertToolPrivate::Run(void) {
 // ---------------------------------------------
 // RevertTool implementation
 
-RevertTool::RevertTool(void)
+RevertTool::RevertTool()
     : AbstractTool()
     , m_settings(new RevertSettings)
     , m_impl(0)
@@ -163,7 +163,7 @@ RevertTool::RevertTool(void)
     Options::AddOption("-keepQualities", "keep base qualities (do not replace with OQ contents)", m_settings->IsKeepQualities, RevertOpts);
 }
 
-RevertTool::~RevertTool(void) {
+RevertTool::~RevertTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -172,7 +172,7 @@ RevertTool::~RevertTool(void) {
     m_impl = 0;
 }
 
-int RevertTool::Help(void) {
+int RevertTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_revert.h
+++ b/src/toolkit/bamtools_revert.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class RevertTool : public AbstractTool {
 
     public:
-        RevertTool(void);
-        ~RevertTool(void);
+        RevertTool();
+        ~RevertTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_sort.cpp
+++ b/src/toolkit/bamtools_sort.cpp
@@ -59,7 +59,7 @@ struct SortTool::SortSettings {
     unsigned int MaxBufferMemory;
 
     // constructor
-    SortSettings(void)
+    SortSettings()
         : HasInputBamFilename(false)
         , HasMaxBufferCount(false)
         , HasMaxBufferMemory(false)
@@ -80,17 +80,17 @@ class SortTool::SortToolPrivate {
     // ctor & dtor
     public:
         SortToolPrivate(SortTool::SortSettings* settings);
-        ~SortToolPrivate(void) { }
+        ~SortToolPrivate() { }
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
         bool CreateSortedTempFile(std::vector<BamAlignment>& buffer);
-        bool GenerateSortedRuns(void);
-        bool MergeSortedRuns(void);
+        bool GenerateSortedRuns();
+        bool MergeSortedRuns();
         bool WriteTempFile(const std::vector<BamAlignment>& buffer, const std::string& tempFilename);
         void SortBuffer(std::vector<BamAlignment>& buffer);
 
@@ -120,7 +120,7 @@ SortTool::SortToolPrivate::SortToolPrivate(SortTool::SortSettings* settings)
 }
 
 // generates mutiple sorted temp BAM files from single unsorted BAM file
-bool SortTool::SortToolPrivate::GenerateSortedRuns(void) {
+bool SortTool::SortToolPrivate::GenerateSortedRuns() {
 
     // open input BAM file
     BamReader reader;
@@ -225,7 +225,7 @@ bool SortTool::SortToolPrivate::CreateSortedTempFile(std::vector<BamAlignment>& 
 }
 
 // merges sorted temp BAM files into single sorted output BAM file
-bool SortTool::SortToolPrivate::MergeSortedRuns(void) {
+bool SortTool::SortToolPrivate::MergeSortedRuns() {
 
     // open up multi reader for all of our temp files
     // this might get broken up if we do a multi-pass system later ??
@@ -266,7 +266,7 @@ bool SortTool::SortToolPrivate::MergeSortedRuns(void) {
     return true;
 }
 
-bool SortTool::SortToolPrivate::Run(void) {
+bool SortTool::SortToolPrivate::Run() {
 
     // this does a single pass, chunking up the input file into smaller sorted temp files,
     // then write out using BamMultiReader to handle merging
@@ -315,7 +315,7 @@ bool SortTool::SortToolPrivate::WriteTempFile(const std::vector<BamAlignment>& b
 // ---------------------------------------------
 // SortTool implementation
 
-SortTool::SortTool(void)
+SortTool::SortTool()
     : AbstractTool()
     , m_settings(new SortSettings)
     , m_impl(0)
@@ -344,7 +344,7 @@ SortTool::SortTool(void)
                             MemOpts, SORT_DEFAULT_MAX_BUFFER_MEMORY);
 }
 
-SortTool::~SortTool(void) {
+SortTool::~SortTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -353,7 +353,7 @@ SortTool::~SortTool(void) {
     m_impl = 0;
 }
 
-int SortTool::Help(void) {
+int SortTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_sort.h
+++ b/src/toolkit/bamtools_sort.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class SortTool : public AbstractTool {
 
     public:
-        SortTool(void);
-        ~SortTool(void);
+        SortTool();
+        ~SortTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_split.cpp
+++ b/src/toolkit/bamtools_split.cpp
@@ -34,7 +34,7 @@ static const std::string SPLIT_SINGLE_TOKEN    = ".SINGLE_END";
 static const std::string SPLIT_REFERENCE_TOKEN = ".REF_";
 static const std::string SPLIT_TAG_TOKEN       = ".TAG_";
 
-std::string GetTimestampString(void) {
+std::string GetTimestampString() {
 
     // get human readable timestamp
     time_t currentTime;
@@ -86,7 +86,7 @@ struct SplitTool::SplitSettings {
     std::string ListTagDelimiter;
 
     // constructor
-    SplitSettings(void)
+    SplitSettings()
         : HasInputFilename(false)
         , HasCustomOutputStub(false)
         , HasCustomRefPrefix(false)
@@ -116,13 +116,13 @@ class SplitTool::SplitToolPrivate {
             : m_settings(settings)
         { }
 
-        ~SplitToolPrivate(void) {
+        ~SplitToolPrivate() {
             m_reader.Close();
         }
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
@@ -130,18 +130,18 @@ class SplitTool::SplitToolPrivate {
         template<typename T>
         void CloseWriters(std::map<T, BamWriter*>& writers);
         // calculate output stub based on IO args given
-        void DetermineOutputFilenameStub(void);
+        void DetermineOutputFilenameStub();
         // open our BamReader
-        bool OpenReader(void);
+        bool OpenReader();
         // split alignments in BAM file based on isMapped property
-        bool SplitMapped(void);
+        bool SplitMapped();
         // split alignments in BAM file based on isPaired property
-        bool SplitPaired(void);
+        bool SplitPaired();
         // split alignments in BAM file based on refID property
-        bool SplitReference(void);
+        bool SplitReference();
         // finds first alignment and calls corresponding SplitTagImpl<>
         // depending on tag type
-        bool SplitTag(void);
+        bool SplitTag();
 
     public:
 
@@ -162,7 +162,7 @@ class SplitTool::SplitToolPrivate {
         RefVector m_references;
 };
 
-void SplitTool::SplitToolPrivate::DetermineOutputFilenameStub(void) {
+void SplitTool::SplitToolPrivate::DetermineOutputFilenameStub() {
 
     // if user supplied output filename stub, use that
     if ( m_settings->HasCustomOutputStub )
@@ -177,7 +177,7 @@ void SplitTool::SplitToolPrivate::DetermineOutputFilenameStub(void) {
     else m_outputFilenameStub = GetTimestampString();
 }
 
-bool SplitTool::SplitToolPrivate::OpenReader(void) {
+bool SplitTool::SplitToolPrivate::OpenReader() {
 
     // attempt to open BAM file
     if ( !m_reader.Open(m_settings->InputFilename) ) {
@@ -191,7 +191,7 @@ bool SplitTool::SplitToolPrivate::OpenReader(void) {
     return true;
 }
 
-bool SplitTool::SplitToolPrivate::Run(void) {
+bool SplitTool::SplitToolPrivate::Run() {
 
     // determine output stub
     DetermineOutputFilenameStub();
@@ -212,7 +212,7 @@ bool SplitTool::SplitToolPrivate::Run(void) {
     return false;
 }
 
-bool SplitTool::SplitToolPrivate::SplitMapped(void) {
+bool SplitTool::SplitToolPrivate::SplitMapped() {
 
     // set up splitting data structure
     std::map<bool, BamWriter*> outputFiles;
@@ -261,7 +261,7 @@ bool SplitTool::SplitToolPrivate::SplitMapped(void) {
     return true;
 }
 
-bool SplitTool::SplitToolPrivate::SplitPaired(void) {
+bool SplitTool::SplitToolPrivate::SplitPaired() {
 
     // set up splitting data structure
     std::map<bool, BamWriter*> outputFiles;
@@ -310,7 +310,7 @@ bool SplitTool::SplitToolPrivate::SplitPaired(void) {
     return true;
 }
 
-bool SplitTool::SplitToolPrivate::SplitReference(void) {
+bool SplitTool::SplitToolPrivate::SplitReference() {
 
     // set up splitting data structure
     std::map<int32_t, BamWriter*> outputFiles;
@@ -377,7 +377,7 @@ bool SplitTool::SplitToolPrivate::SplitReference(void) {
 }
 
 // finds first alignment and calls corresponding SplitTagImpl<>() depending on tag type
-bool SplitTool::SplitToolPrivate::SplitTag(void) {
+bool SplitTool::SplitToolPrivate::SplitTag() {
 
     // iterate through alignments, until we hit TAG
     BamAlignment al;
@@ -635,7 +635,7 @@ bool SplitTool::SplitToolPrivate::SplitTagImpl(BamAlignment& al) {
 // ---------------------------------------------
 // SplitTool implementation
 
-SplitTool::SplitTool(void)
+SplitTool::SplitTool()
     : AbstractTool()
     , m_settings(new SplitSettings)
     , m_impl(0)
@@ -667,7 +667,7 @@ SplitTool::SplitTool(void)
                             m_settings->IsSplittingTag, m_settings->TagToSplit, SplitOpts);
 }
 
-SplitTool::~SplitTool(void) {
+SplitTool::~SplitTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -676,7 +676,7 @@ SplitTool::~SplitTool(void) {
     m_impl = 0;
 }
 
-int SplitTool::Help(void) {
+int SplitTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_split.h
+++ b/src/toolkit/bamtools_split.h
@@ -18,11 +18,11 @@ namespace BamTools {
 class SplitTool : public AbstractTool {
 
     public:
-        SplitTool(void);
-        ~SplitTool(void);
+        SplitTool();
+        ~SplitTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_stats.cpp
+++ b/src/toolkit/bamtools_stats.cpp
@@ -37,7 +37,7 @@ struct StatsTool::StatsSettings {
     std::string InputFilelist;
 
     // constructor
-    StatsSettings(void)
+    StatsSettings()
         : HasInput(false)
         , HasInputFilelist(false)
         , IsShowingInsertSizeSummary(false)
@@ -52,16 +52,16 @@ struct StatsTool::StatsToolPrivate {
     // ctor & dtor
     public:
         StatsToolPrivate(StatsTool::StatsSettings* _settings);
-        ~StatsToolPrivate(void) { }
+        ~StatsToolPrivate() { }
 
     // 'public' interface
     public:
-        bool Run(void);
+        bool Run();
 
     // internal methods
     private:
         bool CalculateMedian(std::vector<int>& data, double& median);
-        void PrintStats(void);
+        void PrintStats();
         void ProcessAlignment(const BamAlignment& al);
 
     // data members
@@ -130,7 +130,7 @@ bool StatsTool::StatsToolPrivate::CalculateMedian(std::vector<int>& data, double
 }
 
 // print BAM file alignment stats
-void StatsTool::StatsToolPrivate::PrintStats(void) {
+void StatsTool::StatsToolPrivate::PrintStats() {
 
     std::cout << std::endl;
     std::cout << "**********************************************" << std::endl;
@@ -259,7 +259,7 @@ bool StatsTool::StatsToolPrivate::Run() {
 // ---------------------------------------------
 // StatsTool implementation
 
-StatsTool::StatsTool(void)
+StatsTool::StatsTool()
     : AbstractTool()
     , m_settings(new StatsSettings)
     , m_impl(0)
@@ -276,7 +276,7 @@ StatsTool::StatsTool(void)
     Options::AddOption("-insert", "summarize insert size data", m_settings->IsShowingInsertSizeSummary, AdditionalOpts);
 }
 
-StatsTool::~StatsTool(void) {
+StatsTool::~StatsTool() {
 
     delete m_settings;
     m_settings = 0;
@@ -285,7 +285,7 @@ StatsTool::~StatsTool(void) {
     m_impl = 0;
 }
 
-int StatsTool::Help(void) {
+int StatsTool::Help() {
     Options::DisplayHelp();
     return 0;
 }

--- a/src/toolkit/bamtools_stats.h
+++ b/src/toolkit/bamtools_stats.h
@@ -17,11 +17,11 @@ namespace BamTools {
 class StatsTool : public AbstractTool {
 
     public:
-        StatsTool(void);
-        ~StatsTool(void);
+        StatsTool();
+        ~StatsTool();
 
     public:
-        int Help(void);
+        int Help();
         int Run(int argc, char* argv[]);
 
     private:

--- a/src/toolkit/bamtools_tool.h
+++ b/src/toolkit/bamtools_tool.h
@@ -18,16 +18,16 @@ namespace BamTools {
 class AbstractTool {
 
     public:
-        AbstractTool(void) { }
-        virtual ~AbstractTool(void) { }
+        AbstractTool() { }
+        virtual ~AbstractTool() { }
 
     public:
-        virtual int Help(void) =0;
+        virtual int Help() =0;
         virtual int Run(int argc, char* argv[]) =0;
 
     // derived classes should also provide:
-    // static std::string Description(void);
-    // static std::String Name(void);
+    // static std::string Description();
+    // static std::String Name();
 };
 
 } // namespace BamTools

--- a/src/utils/bamtools_fasta.cpp
+++ b/src/utils/bamtools_fasta.cpp
@@ -39,11 +39,11 @@ struct Fasta::FastaPrivate {
     std::vector<FastaIndexData> Index;
 
     // ctor
-    FastaPrivate(void);
-    ~FastaPrivate(void);
+    FastaPrivate();
+    ~FastaPrivate();
 
     // 'public' API methods
-    bool Close(void);
+    bool Close();
     bool CreateIndex(const std::string& indexFilename);
     bool GetBase(const int& refId, const int& position, char& base);
     bool GetSequence(const int& refId, const int& start, const int& stop, std::string& sequence);
@@ -55,18 +55,18 @@ struct Fasta::FastaPrivate {
         bool GetNameFromHeader(const std::string& header, std::string& name);
         bool GetNextHeader(std::string& header);
         bool GetNextSequence(std::string& sequence);
-        bool LoadIndexData(void);
-        bool Rewind(void);
-        bool WriteIndexData(void);
+        bool LoadIndexData();
+        bool Rewind();
+        bool WriteIndexData();
 };
 
-Fasta::FastaPrivate::FastaPrivate(void)
+Fasta::FastaPrivate::FastaPrivate()
     : IsOpen(false)
     , HasIndex(false)
     , IsIndexOpen(false)
 { }
 
-Fasta::FastaPrivate::~FastaPrivate(void) {
+Fasta::FastaPrivate::~FastaPrivate() {
     Close();
 }
 
@@ -91,7 +91,7 @@ void Fasta::FastaPrivate::Chomp(char* sequence) {
     }
 }
 
-bool Fasta::FastaPrivate::Close(void) {
+bool Fasta::FastaPrivate::Close() {
 
     // close fasta file
     if ( IsOpen ) {
@@ -477,7 +477,7 @@ bool Fasta::FastaPrivate::GetSequence(const int& refId, const int& start, const 
     return true;
 }
 
-bool Fasta::FastaPrivate::LoadIndexData(void) {
+bool Fasta::FastaPrivate::LoadIndexData() {
 
     // skip if no index file available
     if ( !IsIndexOpen ) return false;
@@ -553,12 +553,12 @@ bool Fasta::FastaPrivate::Open(const std::string& filename, const std::string& i
     return success;
 }
 
-bool Fasta::FastaPrivate::Rewind(void) {
+bool Fasta::FastaPrivate::Rewind() {
     if ( !IsOpen ) return false;
     return ( fseeko(Stream, 0, SEEK_SET) == 0 );
 }
 
-bool Fasta::FastaPrivate::WriteIndexData(void) {
+bool Fasta::FastaPrivate::WriteIndexData() {
 
     // skip if no index file available
     if ( !IsIndexOpen ) return false;
@@ -592,16 +592,16 @@ bool Fasta::FastaPrivate::WriteIndexData(void) {
 // --------------------------------
 // Fasta implementation
 
-Fasta::Fasta(void) {
+Fasta::Fasta() {
     d = new FastaPrivate;
 }
 
-Fasta::~Fasta(void) {
+Fasta::~Fasta() {
     delete d;
     d = 0;
 }
 
-bool Fasta::Close(void) {
+bool Fasta::Close() {
     return d->Close();
 }
 

--- a/src/utils/bamtools_fasta.h
+++ b/src/utils/bamtools_fasta.h
@@ -19,12 +19,12 @@ class UTILS_EXPORT Fasta {
 
     // ctor & dtor
     public:
-        Fasta(void);
-        ~Fasta(void);
+        Fasta();
+        ~Fasta();
 
     // file-handling methods
     public:
-        bool Close(void);
+        bool Close();
         bool Open(const std::string& filename, const std::string& indexFilename = "");
 
     // sequence access methods

--- a/src/utils/bamtools_filter_engine.h
+++ b/src/utils/bamtools_filter_engine.h
@@ -73,7 +73,7 @@ class UTILS_EXPORT FilterEngine {
 
     // ctor & dtor
     public:
-        FilterEngine(void)
+        FilterEngine()
             : m_ruleString("")
             , m_isRuleQueueGenerated(false)
             , m_defaultCompareType(FilterCompareType::OR)
@@ -82,7 +82,7 @@ class UTILS_EXPORT FilterEngine {
             , NOT_OPERATOR("!")
         { }
 
-        ~FilterEngine(void) { }
+        ~FilterEngine() { }
 
     // 'filter set' methods
     public:
@@ -90,7 +90,7 @@ class UTILS_EXPORT FilterEngine {
         bool addFilter(const std::string& filterName);
 
         // return list of current filter names
-        const std::vector<std::string> filterNames(void);
+        const std::vector<std::string> filterNames();
 
     // 'property' methods
     public:
@@ -107,10 +107,10 @@ class UTILS_EXPORT FilterEngine {
                          const PropertyFilterValue::ValueCompareType& type = PropertyFilterValue::EXACT);
 
         // returns list of all properties known by FilterEngine  ( any created using addProperty() )
-        const std::vector<std::string> allPropertyNames(void);
+        const std::vector<std::string> allPropertyNames();
 
         // returns list of property names that are 'enabled' ( only those touched by setProperty() )
-        const std::vector<std::string> enabledPropertyNames(void);
+        const std::vector<std::string> enabledPropertyNames();
 
      // 'rule' methods
     public:
@@ -136,8 +136,8 @@ class UTILS_EXPORT FilterEngine {
 
     // internal rule-handling methods
     private:
-        void buildDefaultRuleString(void);
-        void buildRuleQueue(void);
+        void buildDefaultRuleString();
+        void buildRuleQueue();
         template<typename T>
         bool evaluateFilterRules(const T& query);
 
@@ -199,7 +199,7 @@ inline bool FilterEngine<FilterChecker>::addProperty(const std::string& property
 // returns list of all properties known by FilterEngine
 // ( any that were created using addProperty() )
 template<typename FilterChecker>
-inline const std::vector<std::string> FilterEngine<FilterChecker>::allPropertyNames(void) {
+inline const std::vector<std::string> FilterEngine<FilterChecker>::allPropertyNames() {
     // set up stringlist
     std::vector<std::string> names;
     names.reserve(m_properties.size());
@@ -215,7 +215,7 @@ inline const std::vector<std::string> FilterEngine<FilterChecker>::allPropertyNa
 // builds a default rule string based on m_defaultCompareType
 // used if user supplied an explicit rule string
 template<typename FilterChecker>
-inline void FilterEngine<FilterChecker>::buildDefaultRuleString(void) {
+inline void FilterEngine<FilterChecker>::buildDefaultRuleString() {
 
     // set up temp string stream
     std::stringstream ruleStream;
@@ -238,7 +238,7 @@ inline void FilterEngine<FilterChecker>::buildDefaultRuleString(void) {
 
 // build expression queue based on ruleString
 template<typename FilterChecker>
-inline void FilterEngine<FilterChecker>::buildRuleQueue(void) {
+inline void FilterEngine<FilterChecker>::buildRuleQueue() {
 
     // skip if no filters present
     if ( m_filters.empty() ) return;
@@ -270,7 +270,7 @@ bool FilterEngine<FilterChecker>::check(const T& query) {
 
 // returns list of property names that are 'enabled' ( only those touched by setProperty() )
 template<typename FilterChecker>
-inline const std::vector<std::string> FilterEngine<FilterChecker>::enabledPropertyNames(void) {
+inline const std::vector<std::string> FilterEngine<FilterChecker>::enabledPropertyNames() {
     // initialize stringlist
     std::vector<std::string> names;
     names.reserve(m_properties.size());
@@ -341,7 +341,7 @@ bool FilterEngine<FilterChecker>::evaluateFilterRules(const T& query) {
 
 // return list of current filter names
 template<typename FilterChecker>
-inline const std::vector<std::string> FilterEngine<FilterChecker>::filterNames(void) {
+inline const std::vector<std::string> FilterEngine<FilterChecker>::filterNames() {
     // initialize stringlist
     std::vector<std::string> names;
     names.reserve(m_filters.size());

--- a/src/utils/bamtools_filter_ruleparser.h
+++ b/src/utils/bamtools_filter_ruleparser.h
@@ -102,19 +102,19 @@ class RuleParser {
             ignoreQuotes();
         }
 
-        ~RuleParser(void) { }
+        ~RuleParser() { }
 
     // public interface
     public:
-        void parse(void);
-        std::queue<std::string> results(void) const { return m_ruleQueue; }
+        void parse();
+        std::queue<std::string> results() const { return m_ruleQueue; }
 
     // internal methods
     private:
-        char getNextChar(void);
-        void ignoreQuotes(void);
+        char getNextChar();
+        void ignoreQuotes();
         bool readToken(RuleToken& token);
-        void skipSpaces(void);
+        void skipSpaces();
 
     // data members
     private:
@@ -128,19 +128,19 @@ class RuleParser {
 };
 
 inline
-char RuleParser::getNextChar(void) {
+char RuleParser::getNextChar() {
    if ( m_current == m_end ) return 0;
    return *m_current++;
 }
 
 inline
-void RuleParser::ignoreQuotes(void) {
+void RuleParser::ignoreQuotes() {
     if ( *m_begin == '\"' ) ++m_begin;
     if ( *m_end   == '\"' ) --m_end;
 }
 
 inline
-void RuleParser::parse(void) {
+void RuleParser::parse() {
 
     // clear out any prior data
     while ( !m_ruleQueue.empty() )
@@ -305,7 +305,7 @@ bool RuleParser::readToken(RuleToken& token) {
 }
 
 inline
-void RuleParser::skipSpaces(void) {
+void RuleParser::skipSpaces() {
     while ( m_current != m_end ) {
         const char c = *m_current;
         if ( c == ' ' || c == '\t' || c == '\r' || c == '\n')

--- a/src/utils/bamtools_options.cpp
+++ b/src/utils/bamtools_options.cpp
@@ -61,7 +61,7 @@ OptionGroup* Options::CreateOptionGroup(const std::string& groupName) {
 }
 
 // displays the help menu
-void Options::DisplayHelp(void) {
+void Options::DisplayHelp() {
 
     // initialize
     char argumentBuffer[ARGUMENT_LENGTH + 1];
@@ -280,7 +280,7 @@ void Options::SetProgramInfo(const std::string& programName,
 }
 
 // return string representations of stdin
-const std::string& Options::StandardIn(void) { return m_stdin; }
+const std::string& Options::StandardIn() { return m_stdin; }
 
 // return string representations of stdout
-const std::string& Options::StandardOut(void) { return m_stdout; }
+const std::string& Options::StandardOut() { return m_stdout; }

--- a/src/utils/bamtools_options.h
+++ b/src/utils/bamtools_options.h
@@ -57,7 +57,7 @@ struct UTILS_EXPORT Option {
     Variant DefaultValue;
 
     // constructor
-    Option(void)
+    Option()
         : StoreValue(true)
         , HasDefaultValue(false)
     { }
@@ -75,7 +75,7 @@ struct UTILS_EXPORT OptionValue {
     Variant VariantValue;
 
     // constructor
-    OptionValue(void)
+    OptionValue()
         : pFoundArgument(NULL)
         , pValue(NULL)
         , UseVector(false)
@@ -125,7 +125,7 @@ class UTILS_EXPORT Options {
         // creates an option group
         static OptionGroup* CreateOptionGroup(const std::string& groupName);
         // displays the help menu
-        static void DisplayHelp(void);
+        static void DisplayHelp();
         // parses the command line
         static void Parse(int argc, char* argv[], int offset = 0);
         // sets the program info
@@ -133,9 +133,9 @@ class UTILS_EXPORT Options {
                                    const std::string& description,
                                    const std::string& arguments);
         // returns string representation of stdin
-        static const std::string& StandardIn(void);
+        static const std::string& StandardIn();
         // returns string representation of stdout
-        static const std::string& StandardOut(void);
+        static const std::string& StandardOut();
 
     // static data members
     private:

--- a/src/utils/bamtools_pileup_engine.cpp
+++ b/src/utils/bamtools_pileup_engine.cpp
@@ -27,22 +27,22 @@ struct PileupEngine::PileupEnginePrivate {
     std::vector<PileupVisitor*> Visitors;
 
     // ctor & dtor
-    PileupEnginePrivate(void)
+    PileupEnginePrivate()
         : CurrentId(-1)
         , CurrentPosition(-1)
         , IsFirstAlignment(true)
     { }
-    ~PileupEnginePrivate(void) { }
+    ~PileupEnginePrivate() { }
 
     // 'public' methods
     bool AddAlignment(const BamAlignment& al);
-    void Flush(void);
+    void Flush();
 
     // internal methods
     private:
-        void ApplyVisitors(void);
-        void ClearOldData(void);
-        void CreatePileupData(void);
+        void ApplyVisitors();
+        void ClearOldData();
+        void CreatePileupData();
         void ParseAlignmentCigar(const BamAlignment& al);
 };
 
@@ -112,7 +112,7 @@ bool PileupEngine::PileupEnginePrivate::AddAlignment(const BamAlignment& al) {
     return true;
 }
 
-void PileupEngine::PileupEnginePrivate::ApplyVisitors(void) {
+void PileupEngine::PileupEnginePrivate::ApplyVisitors() {
 
     // parse CIGAR data in BamAlignments to build up current pileup data
     CreatePileupData();
@@ -124,7 +124,7 @@ void PileupEngine::PileupEnginePrivate::ApplyVisitors(void) {
         (*visitorIter)->Visit(CurrentPileupData);
 }
 
-void PileupEngine::PileupEnginePrivate::ClearOldData(void) {
+void PileupEngine::PileupEnginePrivate::ClearOldData() {
 
     // remove any alignments that end before our CurrentPosition
     // N.B. - BAM positions are 0-based, half-open. GetEndPosition() returns a 1-based position,
@@ -158,7 +158,7 @@ void PileupEngine::PileupEnginePrivate::ClearOldData(void) {
     CurrentAlignments.resize(j);
 }
 
-void PileupEngine::PileupEnginePrivate::CreatePileupData(void) {
+void PileupEngine::PileupEnginePrivate::CreatePileupData() {
 
     // remove any non-overlapping alignments
     ClearOldData();
@@ -175,7 +175,7 @@ void PileupEngine::PileupEnginePrivate::CreatePileupData(void) {
         ParseAlignmentCigar( (*alIter) );
 }
 
-void PileupEngine::PileupEnginePrivate::Flush(void) {
+void PileupEngine::PileupEnginePrivate::Flush() {
     while ( !CurrentAlignments.empty() ) {
         ApplyVisitors();
         ++CurrentPosition;
@@ -331,15 +331,15 @@ void PileupEngine::PileupEnginePrivate::ParseAlignmentCigar(const BamAlignment& 
 // ---------------------------------------------
 // PileupEngine implementation
 
-PileupEngine::PileupEngine(void)
+PileupEngine::PileupEngine()
     : d( new PileupEnginePrivate )
 { }
 
-PileupEngine::~PileupEngine(void) {
+PileupEngine::~PileupEngine() {
     delete d;
     d = 0;
 }
 
 bool PileupEngine::AddAlignment(const BamAlignment& al) { return d->AddAlignment(al); }
 void PileupEngine::AddVisitor(PileupVisitor* visitor) { d->Visitors.push_back(visitor); }
-void PileupEngine::Flush(void) { d->Flush(); }
+void PileupEngine::Flush() { d->Flush(); }

--- a/src/utils/bamtools_pileup_engine.h
+++ b/src/utils/bamtools_pileup_engine.h
@@ -67,8 +67,8 @@ struct UTILS_EXPORT PileupPosition {
 class UTILS_EXPORT PileupVisitor {
 
     public:
-        PileupVisitor(void) { }
-        virtual ~PileupVisitor(void) { }
+        PileupVisitor() { }
+        virtual ~PileupVisitor() { }
 
     public:
         virtual void Visit(const PileupPosition& pileupData) =0;
@@ -77,13 +77,13 @@ class UTILS_EXPORT PileupVisitor {
 class UTILS_EXPORT PileupEngine {
 
     public:
-        PileupEngine(void);
-        ~PileupEngine(void);
+        PileupEngine();
+        ~PileupEngine();
 
     public:
         bool AddAlignment(const BamAlignment& al);
         void AddVisitor(PileupVisitor* visitor);
-        void Flush(void);
+        void Flush();
 
     private:
         struct PileupEnginePrivate;

--- a/src/utils/bamtools_variant.h
+++ b/src/utils/bamtools_variant.h
@@ -27,7 +27,7 @@ namespace BamTools {
 class UTILS_EXPORT Variant {
 
     public:
-        Variant(void) : data(NULL) { }
+        Variant() : data(NULL) { }
 
         Variant(const Variant& other) {
             if ( other.data != NULL )
@@ -35,7 +35,7 @@ class UTILS_EXPORT Variant {
             data = other.data;
         }
 
-        ~Variant(void) {
+        ~Variant() {
             if ( data != NULL )
                 data->Release();
         }
@@ -72,12 +72,12 @@ class UTILS_EXPORT Variant {
         // This forms returns a REFERENCE and not a COPY, which
         // will be significant in some cases.
         template<typename T>
-        const T& get(void) const {
+        const T& get() const {
             return CastFromBase<T>(data)->data;
         }
 
         template<typename T>
-        bool is_type(void) const {
+        bool is_type() const {
             return typeid(*data)==typeid(Impl<T>);
         }
 
@@ -90,10 +90,10 @@ class UTILS_EXPORT Variant {
         struct ImplBase {
 
             ImplBase() : refs(0) { }
-            virtual ~ImplBase(void) { }
+            virtual ~ImplBase() { }
 
-            void AddRef(void) { ++refs; }
-            void Release(void) {
+            void AddRef() { ++refs; }
+            void Release() {
                 --refs;
                 if ( refs == 0 ) delete this;
             }
@@ -104,7 +104,7 @@ class UTILS_EXPORT Variant {
         template<typename T>
         struct Impl : ImplBase {
             Impl(T v) : data(v) { }
-            ~Impl(void) { }
+            ~Impl() { }
             T data;
         };
 


### PR DESCRIPTION
* ISO C++ since the first C++98 release has never required
  `(void)` prototypes. This is a vestige of ancient K&R C
  and should be avoided in C++, as it adds no clarity or value.