### PR TITLE
Tiddit ships with a patched version of bamtools

### DIFF
--- a/src/api/BamAlignment.cpp
+++ b/src/api/BamAlignment.cpp
@@ -795,6 +795,13 @@ bool BamAlignment::IsSecondMate() const
     return ((AlignmentFlag & Constants::BAM_ALIGNMENT_READ_2) != 0);
 }
 
+/*! \fn bool BamAlignment::IsSupplementaryAlignment() const
+    \return \c true if ailgnment is supplementary (This is an additional patch by tiddit package)
+ */
+bool BamAlignment::IsSupplementaryAlignment(void) const {
+    return ( (AlignmentFlag & Constants::SUPPLEMENTARY) != 0 );
+}
+
 /*! \fn bool BamAlignment::IsValidSize(const std::string& tag, const std::string& type) const
     \internal
 

--- a/src/api/BamAlignment.h
+++ b/src/api/BamAlignment.h
@@ -51,6 +51,7 @@ public:
         const;  // returns true if alignment is part of read that satisfied paired-end resolution
     bool IsReverseStrand() const;  // returns true if alignment mapped to reverse strand
     bool IsSecondMate() const;     // returns true if alignment is second mate on read
+    bool IsSupplementaryAlignment(void) const;	// Additional patch by tiddit package
 
     // manipulate alignment flags
 public:

--- a/src/api/BamConstants.h
+++ b/src/api/BamConstants.h
@@ -43,6 +43,7 @@ const int BAM_ALIGNMENT_READ_2 = 0x0080;
 const int BAM_ALIGNMENT_SECONDARY = 0x0100;
 const int BAM_ALIGNMENT_QC_FAILED = 0x0200;
 const int BAM_ALIGNMENT_DUPLICATE = 0x0400;
+const int SUPPLEMENTARY           = 0x0800;  // Additional patch by tiddit package
 
 // CIGAR constants
 const char* const BAM_CIGAR_LOOKUP = "MIDNSHP=X";


### PR DESCRIPTION
While packaging [tiddit](https://github.com/SciLifeLab/TIDDIT) for Debian Med, we realized that it ships with a patched version of bamtools. Given that this is a simple addition that should not break anything, we've [patched bamtools](https://salsa.debian.org/med-team/bamtools/-/blob/master/debian/patches/tiddit.patch) at Debian with these changes. 
The patch seems to tackle this specific hurdle:

```
/usr/bin/c++   -I/build/tiddit-2.11.0+dfsg/src -I/usr/include/bamtools  -g -O2 -fdebug-prefix-map=/build/tiddit-2.11.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -              D_FORTIFY_SOURCE=2 -O3 -DNDEBUG   -Wno-deprecated -o CMakeFiles/TIDDIT.dir/src/data_structures/findTranslocationsOnTheFly.cpp.o -c /build/tiddit-2.11.0+dfsg/src/data_structures/findTranslocationsOnTheFly.cpp
/build/tiddit-2.11.0+dfsg/src/data_structures/Translocation.cpp: In member function ‘void Window::insertRead(BamTools::BamAlignment, readStatus)’:
/build/tiddit-2.11.0+dfsg/src/data_structures/Translocation.cpp:70:75: error: ‘class BamTools::BamAlignment’ has no member named ‘IsSupplementaryAlignment’
   70 |  if (alignment_split and alignment.IsPrimaryAlignment() and not alignment.IsSupplementaryAlignment() and alignment.MapQuality >= minimum_mapping_quality) {
      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~
```
I ran the tests that come with bamtools and they all passed. [Here is the commit ](https://github.com/SciLifeLab/TIDDIT/commit/f68d31c3aa9c6ded2f141d1df0900d918daad839) from tiddit where they implement these changes. Please review them and let us know in case anything needs to be changed.