### PR TITLE
CMakeLists.txt: CMake >= 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.11)
+# need 3.11 for INCLUDE_GUARD_NAME in GENERATE_EXPORT_HEADER
 
 project(
     BamTools


### PR DESCRIPTION
* `INCLUDE_GUARD_NAME` in `GENERATE_EXPORT_HEADER()` was added in 3.11

Fixes: #216