### PR TITLE
making include folders visible to users

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,9 @@ target_include_directories(
     BamTools PRIVATE
     ${ZLIB_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    SYSTEM INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(
     BamTools PRIVATE


### PR DESCRIPTION
Making the include-folders visible as SYSTEM INTERFACE. This solves for example this issue:
https://github.com/DiltheyLab/HLA-LA/issues/59