### PR TITLE
allow BamWriter deep copy

### DIFF
--- a/src/api/BamWriter.cpp
+++ b/src/api/BamWriter.cpp
@@ -43,8 +43,47 @@ BamWriter::BamWriter()
 */
 BamWriter::~BamWriter()
 {
-    delete d;
-    d = 0;
+    if (d) delete d;
+    d = nullptr;
+}
+
+/*! \fn BamWriter::BamWriter(const BamWriter& bw)
+    \brief copy constructor, deep copy
+*/
+BamWriter::BamWriter(const BamWriter& bw)
+    : d(nullptr)
+{
+    if (bw.d) d = new BamWriterPrivate(*bw.d);
+}
+
+/*! \fn BamWriter::BamWriter()
+    \brief move constructor, shallow copy
+*/
+BamWriter::BamWriter(BamWriter&& bw) noexcept
+    : d(bw.d)
+{
+    bw.d = nullptr;
+}
+
+/*! \fn BamWriter::operator=(const BamWriter& bw)
+    \brief copy assignement operator, deep copy
+*/
+BamWriter& BamWriter::operator=(const BamWriter& bw)
+{
+    if (d) delete d;
+    if (bw.d) d = new BamWriterPrivate(*bw.d);
+    return *this;
+}
+
+/*! \fn BamWriter::operator=(const BamWriter& bw)
+    \brief move assignement operator, shallow copy
+*/
+BamWriter& BamWriter::operator=(BamWriter&& bw) noexcept
+{
+    if (d) delete d;
+    d    = bw.d;
+    bw.d = nullptr;
+    return *this;
 }
 
 /*! \fn BamWriter::Close()

--- a/src/api/BamWriter.h
+++ b/src/api/BamWriter.h
@@ -40,6 +40,10 @@ public:
 public:
     BamWriter();
     ~BamWriter();
+    BamWriter(const BamWriter& bw);
+    BamWriter(BamWriter&& bw) noexcept;
+    BamWriter& operator=(const BamWriter& bw);
+    BamWriter& operator=(BamWriter&& bw) noexcept;
 
     // public interface
 public:

--- a/src/api/internal/bam/BamWriter_p.h
+++ b/src/api/internal/bam/BamWriter_p.h
@@ -40,6 +40,10 @@ class API_NO_EXPORT BamWriterPrivate
 public:
     BamWriterPrivate();
     ~BamWriterPrivate();
+    BamWriterPrivate(const BamWriterPrivate&) = default;
+    BamWriterPrivate(BamWriterPrivate&&) = default;
+    BamWriterPrivate& operator=(const BamWriterPrivate&) = delete;
+    BamWriterPrivate& operator=(const BamWriterPrivate&&) = delete;
 
     // interface methods
 public:


### PR DESCRIPTION
The default copy constructor was implicitly created and only did a shallow copy, leading to a double delete.

Either provide a deep copy constructor or set it as =delete