### PR TITLE
BamWriter: use sizeof(uint32_t) increment to swap bytes for big endian architectures

### DIFF
--- a/src/api/internal/bam/BamWriter_p.cpp
+++ b/src/api/internal/bam/BamWriter_p.cpp
@@ -349,7 +349,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al)
             char* cigarData = new char[packedCigarLength]();
             std::memcpy(cigarData, packedCigar.data(), packedCigarLength);
             if (m_isBigEndian) {
-                for (size_t i = 0; i < packedCigarLength; ++i) {
+                for (size_t i = 0; i < packedCigarLength; i+= sizeof(uint32_t)) {
                     BamTools::SwapEndian_32p(&cigarData[i]);
                 }
             }
@@ -501,7 +501,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al)
             std::memcpy(cigarData, packedCigar.data(), packedCigarLength);
             if (m_isBigEndian) {
                 for (size_t i = 0; i < packedCigarLength;
-                     ++i) {  // FIXME: similarly, this should be "i += 4", not "++i"
+                     i+= sizeof(uint32_t)) {  // FIXME: similarly, this should be "i += 4", not "++i"
                     BamTools::SwapEndian_32p(&cigarData[i]);
                 }
             }


### PR DESCRIPTION
This MR resolves https://github.com/pezmaster31/bamtools/issues/235

Testing:
  - execute [test script](https://git.launchpad.net/ubuntu/+source/bamtools/tree/debian/tests/run-unit-test) on S390
```
$ sh -ex run-unit-test
+ pkg=bamtools
+ [  =  ]
+ mktemp -d /tmp/bamtools-test.XXXXXX
+ AUTOPKGTEST_TMP=/tmp/bamtools-test.T9AwaX
+ trap rm -rf /tmp/bamtools-test.T9AwaX 0 INT QUIT ABRT PIPE TERM
+ cd /tmp/bamtools-test.T9AwaX
+ cp -a /usr/share/doc/bamtools/sam_spec_example.bam .
+ cp -a /usr/share/doc/bamtools/filter_script .
+ gunzip -r filter_script sam_spec_example.bam
+ bamtools convert -format fastq -in sam_spec_example.bam -out test.fastq
+ bamtools convert -format json -in sam_spec_example.bam -out test.json
+ bamtools count -in sam_spec_example.bam
6
+ bamtools coverage -in sam_spec_example.bam -out out
+ dpkg --print-architecture
+ ARCH=s390x
+ [ s390x != ppc64el -a s390x != arm64 -a s390x != armel-a s390x != armhf -a s390x != s390x ]
run-unit-test: 27: [: armel-a: unexpected operator
+ [ s390x = ppc64el ]
+ echo The following test is known to time out on s390x architecture (see bug #953939)
The following test is known to time out on s390x architecture (see bug #953939)
+ echo bamtools filter -script filter_script -in sam_spec_example.bam -out out.bam
bamtools filter -script filter_script -in sam_spec_example.bam -out out.bam
+ bamtools header -in sam_spec_example.bam
@HD	VN:1.5	SO:coordinate
@SQ	SN:ref	LN:45

+ bamtools index -in sam_spec_example.bam
+ bamtools random -n 100 -in sam_spec_example.bam -out out.bam
+ bamtools revert -in sam_spec_example.bam -out out.bam
+ bamtools sort -in sam_spec_example.bam -out out.bam
+ bamtools split -mapped -in sam_spec_example.bam
+ bamtools stats -in sam_spec_example.bam

**********************************************
Stats for BAM file(s): 
**********************************************

Total reads:       6
Mapped reads:      6	(100%)
Forward strand:    4	(66.6667%)
Reverse strand:    2	(33.3333%)
Failed QC:         0	(0%)
Duplicates:        0	(0%)
Paired-end reads:  2	(33.3333%)
'Proper-pairs':    2	(100%)
Both pairs mapped: 2	(100%)
Read 1:            1
Read 2:            1
Singletons:        0	(0%)

+ rm -rf /tmp/bamtools-test.T9AwaX
```