### PR TITLE
s/t/bamtools_filter.cpp: simplify GetScriptContents().

### DIFF
--- a/src/toolkit/bamtools_filter.cpp
+++ b/src/toolkit/bamtools_filter.cpp
@@ -540,22 +540,18 @@ const std::string FilterTool::FilterToolPrivate::GetScriptContents()
     // read in entire script contents
     char buffer[1024];
     std::ostringstream docStream;
-    while (true) {
-
-        // peek ahead, make sure there is data available
-        char ch = fgetc(inFile);
-        ungetc(ch, inFile);
-        if (feof(inFile)) {
+    while (!feof(inFile)) {
+        // read next block of data
+        char *data = fgets(buffer, 1024, inFile);
+        if (data == 0) {
             break;
         }
-
-        // read next block of data
-        if (fgets(buffer, 1024, inFile) == 0) {
+        if (ferror(inFile)) {
             std::cerr << "bamtools filter ERROR: could not read script contents" << std::endl;
             return std::string();
         }
 
-        docStream << buffer;
+        docStream << data;
     }
 
     // close script file


### PR DESCRIPTION
This MR resolves https://github.com/pezmaster31/bamtools/issues/237

Changes:
- Make 'feof(inFile)' a while condition (to avoid infinite loop in the code)
- break when fgets() returns NULL (no data to read)
- check ferror() - fgets() return value is undefined behaviour in this case. 

Testing: 
 - Running 
`bamtools filter -script filter_script -in ./tests/data/sam_spec_example.bam -out out.bam` with filter_script
```
{
  "filters" : 
    [
      { "id" : "inAnyErrorReadGroup",
        "tag" : "RG:ERR*"
      },
      { "id" : "highMapQuality",
        "mapQuality" : ">=75"
      },
      { "id" : "bothMatesMapped",
        "isMapped" : "true",
        "isMateMapped" : "true"
      }
    ],
  "rule" : "!inAnyErrorReadGroup & (highMapQuality | bothMatesMapped)"
}
```
succeeds